### PR TITLE
Set maven dependency scope to provided.

### DIFF
--- a/source/workspace/artifact.rst
+++ b/source/workspace/artifact.rst
@@ -60,5 +60,6 @@ Maven
             <groupId>org.spongepowered</groupId>
             <artifactId>spongeapi</artifactId>
             <version>1.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
It is expected that the Sponge API would be available at runtime, without having to include it in our plugin jar.

Sorry, I don't have the way to do this in Gradle. :)