### PR TITLE
Remove capitalization from "Server"

### DIFF
--- a/source/users/java.rst
+++ b/source/users/java.rst
@@ -21,10 +21,10 @@ What's the Difference Between JRE and JDK?
 
 **JRE**: The JRE (Java Runtime Environment) is required to run any Java program on a system,
 without it, the system cannot create the Java Virtual Machine. If you want to run a Sponge
-(Minecraft) Server, you require the JRE.
+(Minecraft) server, you require the JRE.
 
 **JDK**: The JDK (Java Development Kit) is used by Developers to create programs such as Minecraft,
-as well as Mods and Plugins. If you do not need to do any coding and simply run a Server, you will
+as well as Mods and Plugins. If you do not need to do any coding and simply run a server, you will
 not need the JDK.
 
 
@@ -37,7 +37,7 @@ for anything other than extremely small servers.
 
 **64-bit**: 64-bit Java, while less commonly installed, has numerous advantages over 32-bit.
 The amount of memory that can be allocated increases to approximately 3 TB, so you can throw
-as much memory as your computer has towards your Server. 64-bit Java can also run faster than
+as much memory as your computer has towards your server. 64-bit Java can also run faster than
 32-bit, meaning that you can make the most of your processing power.
 
 How to Install Java On Your Computer

--- a/source/users/platforms.rst
+++ b/source/users/platforms.rst
@@ -17,6 +17,6 @@ However, at the moment, Glowstone does not yet support the Sponge API but it is 
 Granite
 =======
 
-`Granite <http://www.granitepowered.org/>`__ is another Sponge implementation built on top the Minecraft Server.
+`Granite <http://www.granitepowered.org/>`__ is another Sponge implementation built on top the Minecraft server.
 
 Granite is not yet feature-complete, and only early development builds are available. Use at your own risk.


### PR DESCRIPTION
A server is not a proper noun.