### PR TITLE
Switch the links to redirect to the downloads page.

### DIFF
--- a/source/users/quick-start.rst
+++ b/source/users/quick-start.rst
@@ -15,7 +15,7 @@ Single Player / LAN Server
 2. Run the downloaded Forge installer and use it to create a new Forge profile in the Minecraft launcher.
 3. Open the Minecraft launcher and select the new Forge profile that was created.
 4. Click "Options" and then click "Open Game Dir."
-5. Download the `Sponge coremod <http://www.spongepowered.org>`_ and put it into the "mods" folder, creating the folder if it does not yet exist.
+5. Download the :doc:`Sponge coremod </../downloads>` and put it into the "mods" folder, creating the folder if it does not yet exist.
 
 
 Dedicated Server
@@ -24,13 +24,13 @@ Dedicated Server
 New Installation
 ----------------
 
-1. Download the `Sponge server installer <http://www.spongepowered.org>`_.
+1. Download the :doc:`Sponge server installer </../downloads>`.
 2. Either double click the installer to automatically download the required server files, or if you are on the command line or terminal, use ``java -jar installer.jar`` to download the files.
 
 Existing Forge Server
 ---------------------
 
-If you already have a Forge server set up, get the `Sponge coremod <http://www.spongepowered.org>`_ and place it into your "mods" folder.
+If you already have a Forge server set up, get the :doc:`Sponge coremod </../downloads>` and place it into your "mods" folder.
 
 
 .. note::


### PR DESCRIPTION
Direct to the downloads page instead of redirecting to the Sponge site.