### PR TITLE
Document SQL service and maven archetype

### DIFF
--- a/source/plugin/advanced/database.rst
+++ b/source/plugin/advanced/database.rst
@@ -1,0 +1,48 @@
+======================
+Working with Databases
+======================
+
+SQL
+---
+Sponge provides a convenient abstraction for establishing JDBC database connections that handles the complexities of establishing an efficient pooled connection from a JDBC URL. 
+
+While the SQL service supports any JDBC connector, the Forge implementation of Sponge only ships with the most common:
+
+- MySQL
+- Sqlite
+- H2
+
+.. warning::
+    Because Sqlite has many limitations, its usage is strongly discouraged except in cases where legacy compatibility is required. H2 is our recommended file-backed database implementation. 
+
+Usage
+~~~~~
+
+A data source can be accessed through the plugin's service manager:
+
+.. code-block:: java
+
+    private final SqlService sql;
+    public javax.sql.DataSource getDataSource(String jdbcUrl) throws SQLException {
+        if (sql == null) {
+            sql = game.getServiceManager().provide(SqlService.class).get();
+        }
+        return sql.getDataSource(jdbcUrl);
+    }
+
+    // Later on
+    public void myMethodThatQueries() throws SQLException {
+        Connection conn = getDataSource("jdbc:h2:imalittledatabaseshortandstout.db").getConnection();
+        try {
+            conn.prepareStatement("SELECT * FROM test_tbl").execute();
+        } finally {
+            conn.close();
+        }
+        
+    }
+
+Because the SQL service provides a pooled connection, getting a Connection from the returned DataSource is not expensive. Because of this, it is recommended to not keep connections around, instead closing them soon after use, as shown in the above example. (yes, you do have to close connections. Proper resource management guys!)
+
+NoSQL
+-----
+Sponge does not currently provide any special abstraction over NoSQL databases (MongoDB etc). Plugins that wish to use NoSQL databases must provide their own connectors

--- a/source/plugin/advanced/index.rst
+++ b/source/plugin/advanced/index.rst
@@ -10,6 +10,7 @@ Contents
     :titlesonly:
 
     adv-configuration
+    database
     permissions
     services
     manager

--- a/source/plugin/basics/index.rst
+++ b/source/plugin/basics/index.rst
@@ -11,6 +11,7 @@ Contents
 
     workspace/index
     practices
+    templates
     main-class
     lifecycle
     logging

--- a/source/plugin/basics/main-class.rst
+++ b/source/plugin/basics/main-class.rst
@@ -2,6 +2,9 @@
 Creating Your Main Plugin Class
 ===============================
 
+.. tip::
+    Using a common build system like Maven or Gradle? We might just have an existing template for you. Check :doc:`templates` to see!
+
 .. note::
 
     The instructions within the Sponge Documentation assume that you have prior knowledge of Java. The Sponge API provides the foundation for you to begin creating plugins for Minecraft servers powered by Sponge; however, it is up to you to be creative and make your code work! There are several free Java courses online if you have had little experience with Java.

--- a/source/plugin/basics/templates.rst
+++ b/source/plugin/basics/templates.rst
@@ -1,0 +1,40 @@
+================
+Plugin Templates
+================
+For convenience, plugin templates are provided for several build systems.
+
+Gradle
+------
+
+Maven
+-----
+Sponge has a simple archetype that generates the basic structure for a plugin.
+
+The generated pom includes a release profile that generates gpg-signed jars for javadocs, binary, and sources as recommended in the guidelines for submitting projects to Sonatype OSS (However, this option is not currently available for Sponge plugins due to the fact that Sponge API is not currently hosted on Maven Central).
+
+Properties
+~~~~~~~~~~
+
+The archetype plugin accepts a few properties
+
+============== ========================== =====================================================================
+Property        Example value              Description
+============== ========================== =====================================================================
+groupId         io.github.user             The maven groupId, useful more for plugins used as dependencies, but should more or less match your package name
+artifactId      myproject                  The project id, also used as plugin id and name of the generated folder
+version         1.0-SNAPSHOT               The initial version for your plugin. Can (and should) be changed as development progresses
+package         io.github.user.myproject   The package your plugin class will be generated in
+githubProject   user/repo                  The github project. If a value is specified that is not user/repo, issue tracking and SCM sections are added to the pom 
+============== ========================== =====================================================================
+
+These can be specified as arguments to Maven in the form ``-Dproperty=value``
+
+Usage
+~~~~~
+This archetype requires Maven 3 or newer. Invoke maven with the goal archetype:generate. Maven will prompt for any required paramaters, but optional parameters must be specified on the command line.
+
+.. code-block:: bash
+
+    $ mvn archetype:generate -DarchetypeCatalog=http://repo.spongepowered.org/maven -DgithubProject=waylon531/spongeparty
+
+This archetype will be in the presented list under the specifier org.spongepowered:sponge-plugin-archetype. 

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -1,3 +1,11 @@
 ===========
 sponge.conf
 ===========
+
+Global configuration
+--------------------
+
+- **sql**:  This section has options relating to the Sponge-provided SQL service
+
+  - **aliases**: The SQL section of Sponge's global config allows defining aliases for database connection URLs. These aliases can be used in place of database URLs in any plugin's configuration that uses the Sponge services to establish database connections.
+


### PR DESCRIPTION
This adds documentation on the SQL service (beginning the sponge.conf pages as well)

I also copied the archetype readme into this documentation under a new plugin templates page.

Would love some review on this to make sure it all makes sense.