### PR TITLE
Add Sponge staff members to "About Sponge"

### DIFF
--- a/source/about/index.rst
+++ b/source/about/index.rst
@@ -28,3 +28,4 @@ Contents
     faq
     future
     license
+    staff

--- a/source/about/introduction.rst
+++ b/source/about/introduction.rst
@@ -35,8 +35,10 @@ Each aspect of the Sponge project is led by a different individual:
 
 * Sponge API development is led by **Zidane**.
 * Sponge coremod development is led by **blood**.
-* Ore development is led by **gratimax**.
+* Web development is led by **gratimax**.
 * SpongeDocs is coordinated by **Inscrutable**.
 * Support is coordinated by **Owexz**.
+
+A full list of staff members may be located at :doc:`staff`.
 
 Our developers are well-versed with Java, and many of them have worked with Minecraft for years and know the ins-and-outs of its mechanics. There are tons of very good developers working on the Sponge project, and it would be nearly impossible to list all of them!

--- a/source/about/staff.rst
+++ b/source/about/staff.rst
@@ -34,7 +34,7 @@ The **Team Leaders** of Sponge each coordinate a separate aspect of the Sponge p
 |                                   | API and Implementation Developer  |
 +-----------------------------------+-----------------------------------+
 | Inscrutable                       | SpongeDocs Editor-in-Chief        |
-|                                   | Chief Mad Scientist at Yggdrasil  |
+|                                   | Chief Mad Scientist at Yggdrasyl  |
 |                                   | Laboratories, makers of FLARD     |
 +-----------------------------------+-----------------------------------+
 | lukegb                            | System Operations Lead            |

--- a/source/about/staff.rst
+++ b/source/about/staff.rst
@@ -1,0 +1,151 @@
+=====
+Staff
+=====
+
+Below is a list of Sponge's staff members. Each section is presented alphabetically.
+
+Project Leaders
+~~~~~~~~~~~~~~~
+
+The **Project Leaders** are the stewards of the Sponge project, and make the final decisions to ensure the project operates efficiently.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| blood                             | Implementation Development Lead   |
++-----------------------------------+-----------------------------------+
+| sk89q                             | Chief Swag Officer                |
++-----------------------------------+-----------------------------------+
+| Zidane                            | API Development Lead              |
+|                                   | LLC Director                      |
++-----------------------------------+-----------------------------------+
+
+Team Leaders
+~~~~~~~~~~~~
+
+The **Team Leaders** of Sponge each coordinate a separate aspect of the Sponge project.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| AbrarSyed                         | Master of ForgeGradle             |
++-----------------------------------+-----------------------------------+
+| gratimax                          | Web Development Lead              |
+|                                   | API and Implementation Developer  |
++-----------------------------------+-----------------------------------+
+| Inscrutable                       | SpongeDocs Editor-in-Chief        |
+|                                   | Chief Mad Scientist at Yggdrasil  |
+|                                   | Laboratories, makers of FLARD     |
++-----------------------------------+-----------------------------------+
+| lukegb                            | System Operations Lead            |
++-----------------------------------+-----------------------------------+
+| Me4502                            | Subreddit Moderation Lead         |
+|                                   | API and Implementation Developer  |
+|                                   | Owexz's Minion (basically)        |
++-----------------------------------+-----------------------------------+
+| Owexz                             | Support and Public Relations Lead |
+|                                   | LLC Director                      |
+|                                   | Chief of Pestering                |
++-----------------------------------+-----------------------------------+
+
+API and Implementation Developers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The **API and Implementation Developers** work on producing the Sponge API and Sponge coremod, respectively.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| Aaron1011                         | Developer                         |
++-----------------------------------+-----------------------------------+
+| Deamon                            | Developer                         |
++-----------------------------------+-----------------------------------+
+| gabizou                           | API Design Specialist             |
+|                                   | Master of "closing in favor of"   |
++-----------------------------------+-----------------------------------+
+| kitskub                           | Developer                         |
++-----------------------------------+-----------------------------------+
+| kobata                            | Developer                         |
++-----------------------------------+-----------------------------------+
+| Minecrell                         | Developer                         |
++-----------------------------------+-----------------------------------+
+| modwizcode                        | Developer                         |
++-----------------------------------+-----------------------------------+
+| Mumfrey                           | Lord of Mixins                    |
++-----------------------------------+-----------------------------------+
+| progwml6                          | Developer                         |
+|                                   | DevOps and IRC Flag Lead          |
++-----------------------------------+-----------------------------------+
+| sibomots                          | Developer                         |
+|                                   | LLC Leader                        |
++-----------------------------------+-----------------------------------+
+| theresajayne                      | Developer                         |
++-----------------------------------+-----------------------------------+
+
+Website Ninjas
+~~~~~~~~~~~~~~
+
+The **Website Ninjas** make the Sponge website look completely awesome.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| Kornagan                          | Graphic Designer                  |
+|                                   | Website Extraordinaire            |
++-----------------------------------+-----------------------------------+
+
+SysOps Ninjas
+~~~~~~~~~~~~~
+
+The **SysOps ninjas** ensure the efficient performance of Sponge's servers.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| armed_troop                       | System Operations Ninja           |
++-----------------------------------+-----------------------------------+
+| GenPage                           | System Operations Ninja           |
++-----------------------------------+-----------------------------------+
+
+SpongeDocs Editors
+~~~~~~~~~~~~~~~~~~
+
+The **SpongeDocs Editors** lovingly write articles for Sponge's official documentation.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| Kodfod                            | Senior Editor                     |
++-----------------------------------+-----------------------------------+
+| Cedeel                            | Editor and Contributor            |
++-----------------------------------+-----------------------------------+
+| hawtre                            | Editor and Contributor            |
++-----------------------------------+-----------------------------------+
+| Pandette                          | Editor and Contributor            |
++-----------------------------------+-----------------------------------+
+| Tyrannokapi                       | Editor and Contributor            |
+|                                   | Space-age Whiz Kid                |
++-----------------------------------+-----------------------------------+
+
+Moderators and Support
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Moderators and members of the Support Team** patrol the forums and IRC channels, and help when needed.
+
++-----------------------------------+-----------------------------------+
+| Name                              | Role                              |
++===================================+===================================+
+| Dockter                           | Moderator                         |
+|                                   | Cat Aficionado                    |
++-----------------------------------+-----------------------------------+
+| drtshock                          | Forum and IRC Moderator           |
++-----------------------------------+-----------------------------------+
+| Grinch                            | Moderator                         |
++-----------------------------------+-----------------------------------+
+| mbaxter                           | Moderator                         |
+|                                   | Chief of Kittens                  |
++-----------------------------------+-----------------------------------+
+| phroa                             | IRC Moderator                     |
++-----------------------------------+-----------------------------------+
+| TnT                               | Cheerleader                       |
++-----------------------------------+-----------------------------------+


### PR DESCRIPTION
This adds a full list of Sponge staff members to the "About Sponge" category.

Thanks to @Owexz for providing me with a list of staff members and their titles (modified a couple). :smile: 