### PR TITLE
Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ We're eagerly looking for translators! Please visit the [CrowdIn translation pag
 You can setup an environment so you can instantly see the changes that make to the docs.
 
 1. [Install Python 2.7 and Sphinx](http://sphinx-doc.org/latest/install.html)
-2. [Install node.js](http://nodejs.org/download/)
+2. [Install pip](https://pip.pypa.io/en/latest/installing.html)
+3. [Install node.js](http://nodejs.org/download/)
 
 In terminal or the command line, within the directory containing this README, run the following commands:
 
-	npm install -g grunt-cli
+	npm install -g gulp
 	npm install
-	grunt
+	pip install -r etc/requirements.txt
+	gulp
 
 Your browser should open to reveal the docs. When you make a change to the documentation, the docs should refresh in the browser (possibly after a few seconds).


### PR DESCRIPTION
This PR updates the readme's "Local Environment" instructions to use Gulp rather than Grunt, as it was changed in f58e6d23a844447c7c867e0f5b49b5022f433923. Also adds instructions for installing pip, and running pip to download all requirements. If pulled, this will resolve #152 .