### PR TITLE
JavaDocs links. Fixes #198

### DIFF
--- a/source/contributing/api/index.rst
+++ b/source/contributing/api/index.rst
@@ -5,7 +5,9 @@ API Development
 Overview
 ========
 
-The Sponge API is a community-developed API allowing developers to write plugins for Minecraft servers that run an implementation of the Sponge API, such as the Sponge coremod.
+The Sponge API is a community-developed API allowing developers to write plugins for Minecraft servers that run an implementation of the Sponge API, such as the Sponge coremod. 
+
+We recommend contributors become familiar with the Sponge API `JavaDocs <https://spongepowered.github.io/SpongeAPI/>`__.
 
 Contents
 ========

--- a/source/contributing/index.rst
+++ b/source/contributing/index.rst
@@ -8,7 +8,7 @@ Overview
 What is this about?
 ~~~~~~~~~~~~~~~~~~~
 
-The articles in this section explain how to get involved with the Sponge Forge coremod, SpongeVanilla, SpongeCommon, the Sponge API, or SpongeDocs. These articles are essentially required reading for anyone who wishes to begin developing or writing for Sponge.
+The articles in this section explain how to get involved with the Sponge Forge coremod, SpongeVanilla, SpongeCommon, the Sponge API, or SpongeDocs. These articles are essentially required reading for anyone who wishes to begin developing or writing for Sponge. We also recommend developers become familiar with the Sponge API `JavaDocs <https://spongepowered.github.io/SpongeAPI/>`__.
 
 Who should read this?
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/plugin/index.rst
+++ b/source/plugin/index.rst
@@ -8,7 +8,7 @@ Overview
 What is this about?
 ~~~~~~~~~~~~~~~~~~~
 
-The articles in this section explain the basic concepts behind creating plugins using the Sponge API. It is important to understand that the intent of this section is to help developers get started with the Sponge API, not to cover every concept. The **``Javadocs <https://spongepowered.github.io/SpongeAPI/>``__** will be of great help to you once you are comfortable with the API.
+The articles in this section explain the basic concepts behind creating plugins using the Sponge API. It is important to understand that the intent of this section is to help developers get started with the Sponge API, not to cover every concept. The `Javadocs <https://spongepowered.github.io/SpongeAPI/>`__ will be of great help to you once you are comfortable with the API.
 
 .. warning::
 

--- a/source/plugin/index.rst
+++ b/source/plugin/index.rst
@@ -8,7 +8,7 @@ Overview
 What is this about?
 ~~~~~~~~~~~~~~~~~~~
 
-The articles in this section explain the basic concepts behind creating plugins using the Sponge API. It is important to understand that the intent of this section is to help developers get started with the Sponge API, not to cover every concept. The **Javadocs** will be of great help to you once you are comfortable with the API.
+The articles in this section explain the basic concepts behind creating plugins using the Sponge API. It is important to understand that the intent of this section is to help developers get started with the Sponge API, not to cover every concept. The **``Javadocs <https://spongepowered.github.io/SpongeAPI/>``__** will be of great help to you once you are comfortable with the API.
 
 .. warning::
 


### PR DESCRIPTION
Change when/if we have http://javadocs.spongepowered.org or similar.