### PR TITLE
Fix mistakenly italicized text

### DIFF
--- a/source/plugin/basics/text.rst
+++ b/source/plugin/basics/text.rst
@@ -96,7 +96,7 @@ Example: Multi-styled Text
 Coloring & Styling Shortcut
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `org.spongepowered.api.text.Texts#of(Object... objects)` method provides a simple way to add color and styling to your text in a much more concise way.
+The ``org.spongepowered.api.text.Texts#of(Object... objects)`` method provides a simple way to add color and styling to your text in a much more concise way.
 
 Example: Color & Style Shortcut
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The class name should have been in double backticks, rather than single backticks, which italicized the text.