### PR TITLE
Correct keyboard mistake

### DIFF
--- a/source/contributing/docs/index.rst
+++ b/source/contributing/docs/index.rst
@@ -5,7 +5,7 @@ SpongeDocs Writing
 Overview
 ========
 
-The Sponge documentation, also referred to as "SpongeDocs," is the official documentation of the Sponge project. The goal of SpongeDocs is to:
+The Sponge documentation, also referred to as "SpongeDocs", is the official documentation of the Sponge project. The goal of SpongeDocs is to:
 
 * Help users set up their own servers powered by a Sponge implementation.
 * Provide developers with information on how to contribute to the Sponge project.


### PR DESCRIPTION
A ',' between '"', instead of next the last.