### PR TITLE
Update SpongeDocs to Java8

### DIFF
--- a/source/contributing/guidelines.rst
+++ b/source/contributing/guidelines.rst
@@ -167,7 +167,7 @@ started quickly, here is an example of properly formatted code:
             if (random.nextBoolean()) {
                 return Optional.of(this.id);
             } else {
-                return Optional.absent();
+                return Optional.empty();
             }
         }
 

--- a/source/plugin/blocks/accessing.rst
+++ b/source/plugin/blocks/accessing.rst
@@ -88,8 +88,8 @@ at a given ``Location`` is a) a Sponge and b) wet, false otherwise.
 
 First, we need to know which ``DataManipulator`` subinterface we need. Those that are applicable to blocks are found in
 the ``org.spongepowered.api.data.manipulator`` and ``org.spongepowered.api.data.manipulator.block`` packages. Then we
-can just pass that class to the ``getManipulator()`` method and get an ``Optional`` in return which will be ``absent()``
+can just pass that class to the ``getManipulator()`` method and get an ``Optional`` in return which will be ``empty()``
 if the ``BlockState`` does not contain data of that type. Since ``WetData`` represents a boolean value, its presence
-equates to ``true``. Its absence (if ``Optional.absent()`` was returned) either signifies ``false``.
+equates to ``true``. Its absence (if ``Optional.empty()`` was returned) either signifies ``false``.
 
 .. TODO refer and link to data api documentation

--- a/source/plugin/blocks/modifying.rst
+++ b/source/plugin/blocks/modifying.rst
@@ -46,7 +46,7 @@ a wet sponge block.
     }
 
 A ``BlockState`` itself and its data are immutable, but it provides the methods ``withData()`` and ``withoutData()``
-both of which will return a new altered ``BlockState`` or ``Optional.absent()`` if the given ``DataManipulator`` is
+both of which will return a new altered ``BlockState`` or ``Optional.empty()`` if the given ``DataManipulator`` is
 not applicable to the kind of block represented by the ``BlockState``.
 
 The ``withData()`` method accepts a ``DataManipulator`` and will try to create a new ``BlockState`` with the given
@@ -95,7 +95,7 @@ The following example will dry the block at a given ``Location``, if possible.
 
 Since the ``WetData`` data manipulator represents boolean data, by removing it we set the wetness of the block (if it
 has any) to false. The ``dryState.isPresent()`` check will fail on block states that can not be wet since ``dryState``
-will be ``Optional.absent()`` in that case.
+will be ``Optional.empty()`` in that case.
 
 Copying Blocks
 ~~~~~~~~~~~~~~

--- a/source/plugin/blocks/tileentities.rst
+++ b/source/plugin/blocks/tileentities.rst
@@ -10,7 +10,7 @@ Identifying Tile Entities and their Type
 ========================================
 
 Again, it all starts with a ``Location``. The ``getTileEntity()`` function will return the tile entity corresponding
-to the block or ``Optional.absent()`` if the block is not a tile entity.
+to the block or ``Optional.empty()`` if the block is not a tile entity.
 
  .. code-block:: java
 
@@ -66,7 +66,7 @@ line, the second attempts to set it and returns the boolean value indicating its
         if (data.isPresent()) {
             return Optional.of(data.get().getLine(0));
         } else {
-            return Optional.absent();
+            return Optional.empty();
         }
     }
 

--- a/source/plugin/commands/arguments.rst
+++ b/source/plugin/commands/arguments.rst
@@ -7,7 +7,7 @@ The Command Builder API comes with a powerful argument parser. It converts the s
 arguments and flags. It also handles TAB completion of arguments.
 
 The parsed arguments are stored in the ``CommandContext`` object. If the parser returns a single object, obtain it with
-``args.<T>getOne(String key)`` (``T`` is the value type). Optional and weak arguments may return ``Optional.absent()``.
+``args.<T>getOne(String key)`` (``T`` is the value type). Optional and weak arguments may return ``Optional.empty()``.
 
 Many of the parsers may return more than one object (e.g. multiple players with a matching username). In that case, you
 must use the ``args.<T>getAll(String key)`` method to get the ``Collection`` of possible matches. **Otherwise, the
@@ -235,12 +235,12 @@ Example: ``Vector2i`` command element usage
 
     // /plottp <x> <y>
     CommandSpec myCommandSpec = CommandSpec.builder()
-            .setDescription(Texts.of("Teleport to a plot"))
-            .setPermission("myplugin.command.plot.tp")
+            .description(Texts.of("Teleport to a plot"))
+            .permission("myplugin.command.plot.tp")
 
-            .setArguments(new Vector2iCommandElement(Texts.of("coordinates")))
+            .arguments(new Vector2iCommandElement(Texts.of("coordinates")))
 
-            .setExecutor(new MyCommandExecutor())
+            .executor(new MyCommandExecutor())
             .build();
 
 .. tip::

--- a/source/plugin/commands/commandcallable.rst
+++ b/source/plugin/commands/commandcallable.rst
@@ -16,6 +16,7 @@ The first step is to create a class for the command. The class has to implement 
 
     import java.util.Collections;
     import java.util.List;
+    import java.util.Optional;
 
     import org.spongepowered.api.Server;
     import org.spongepowered.api.text.Text;
@@ -25,13 +26,11 @@ The first step is to create a class for the command. The class has to implement 
     import org.spongepowered.api.util.command.CommandResult;
     import org.spongepowered.api.util.command.CommandSource;
 
-    import com.google.common.base.Optional;
-
     public class MyBroadcastCommand implements CommandCallable {
 
         private final Optional<Text> desc = Optional.of((Text) Texts.of("Displays a message to all players"));
         private final Optional<Text> help = Optional.of((Text) Texts.of("Displays a message to all players. It has no color support!"));
-        private final Text usage = (Text) Texts.of("<message>");
+        private final Text usage = Texts.of("<message>");
 
         private final Server server;
 
@@ -39,9 +38,9 @@ The first step is to create a class for the command. The class has to implement 
             this.server = server;
         }
 
-        public Optional<CommandResult> process(CommandSource source, String arguments) throws CommandException {
+        public CommandResult process(CommandSource source, String arguments) throws CommandException {
             server.getBroadcastSink().sendMessage(Texts.of(arguments));
-            return Optional.of(CommandResult.success());
+            return CommandResult.success();
         }
 
         public boolean testPermission(CommandSource source) {
@@ -68,7 +67,7 @@ The first step is to create a class for the command. The class has to implement 
 .. tip::
 
     See the `documentation for CommandCallable
-    <http://spongepowered.github.io/SpongeAPI/org/spongepowered/api/service/command/CommandService.html>`_ for the
+    <http://spongepowered.github.io/SpongeAPI/org/spongepowered/api/util/command/CommandCallable.html>`_ for the
     purposes of each method in this example.
 
 Registering the command

--- a/source/plugin/commands/creating.rst
+++ b/source/plugin/commands/creating.rst
@@ -136,7 +136,7 @@ return ``CommandResult.success()`` if the command was successful or ``CommandRes
 where more information needs to be conveyed, a ``CommandResult.builder()`` should be used. It provides the methods
 ``affectedBlocks()``, ``affectedEntities()``, ``affectedItems()``, ``queryResult()`` and ``successCount()`` methods,
 each accepting an integer and setting the attribute of the same name. All attributes that are not set by the builder
-will be absent.
+will be empty.
 
 Command blocks can use those values to modify scoreboard stats, which then can be used for elaborate constructions
 consisting of multiple command blocks. A tutorial how the data is accessed can be found

--- a/source/plugin/entities/spawning.rst
+++ b/source/plugin/entities/spawning.rst
@@ -11,7 +11,7 @@ For example, let's try to spawn a Creeper:
 
 .. code-block:: java
 
-    import com.google.common.base.Optional;
+    import java.util.Optional;
     import org.spongepowered.api.data.key.Keys;
     import org.spongepowered.api.entity.Entity;
     import org.spongepowered.api.entity.EntityTypes;

--- a/source/plugin/text/pagination.rst
+++ b/source/plugin/text/pagination.rst
@@ -21,7 +21,7 @@ First obtain an instance of the ``PaginationService``, and create a new ``Pagina
 	import org.spongepowered.api.service.pagination.PaginationService;
 
 	PaginationService paginationService = plugin.getGame().getServiceManager().provide(PaginationService.class).get();
-	PaginationBuilder builder = paginationService.newBuilder();
+	PaginationBuilder builder = paginationService.builder();
 
 There are two different ways to specify the contents of paginated list:
 

--- a/source/preparing/jdk.rst
+++ b/source/preparing/jdk.rst
@@ -15,16 +15,13 @@ Before installing the JDK, uninstall any older versions of Java that are present
 
 .. note::
 
-    Sponge contributors must use JDK 6 at present to preserve compatibility with underlying implementation. For Plugin
-    development, we recommend Java 8, as older versions of Java are no longer supported. Be aware that many Minecraft
-    servers have not yet migrated to Java 8. If you wish your Plugin to work in all environments, use Java 6, as there
-    are some end users who have not yet updated.
+    Sponge contributors and Plugin authors must use JDK 8 at present as older versions of Java are no longer supported.
+    Be aware that many Minecraft servers have not yet migrated to Java 8. To run Sponge and its plugins properly it's
+    strongly advised to update to Java 8 as Sponge won't run on older Java versions, namely 6 and 7.
 
 Oracle provides free downloads of the Java Development Kit on their website. Ensure that you are installing the JDK
 (Java Development Kit), not the JRE (Java Runtime Environment). There is a difference between the two.
 
-* `Java Development Kit 6 <http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html>`__
-* `Java Development Kit 7 <http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html>`__
 * `Java Development Kit 8 <http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html>`__
 
 Upon completion of the installation process, reboot your computer. The JDK should then be ready for use.

--- a/source/preparing/jdk.rst
+++ b/source/preparing/jdk.rst
@@ -15,9 +15,9 @@ Before installing the JDK, uninstall any older versions of Java that are present
 
 .. note::
 
-    Sponge contributors and Plugin authors must use JDK 8 at present as older versions of Java are no longer supported.
-    Be aware that many Minecraft servers have not yet migrated to Java 8. To run Sponge and its plugins properly it's
-    strongly advised to update to Java 8 as Sponge won't run on older Java versions, namely 6 and 7.
+    Sponge contributors and Plugin authors must use JDK 8, as older versions of Java are no longer supported.
+    Be aware that some Minecraft servers have still not yet migrated to Java 8. To run Sponge and its plugins
+    properly you must update to Java 8, as Sponge won't run on older versions (ie. Java 6 and 7).
 
 Oracle provides free downloads of the Java Development Kit on their website. Ensure that you are installing the JDK
 (Java Development Kit), not the JRE (Java Runtime Environment). There is a difference between the two.

--- a/source/server/getting-started/installation.rst
+++ b/source/server/getting-started/installation.rst
@@ -11,7 +11,7 @@ the :doc:`implementations/index` page.
 
 Instructions for both are listed on this page.
 
-You will also need to :doc:`install Java <jre>`. To recap, Java 8 is recommended, but Java 7 should work too.
+You will also need to :doc:`install Java <jre>`. To recap, Java 8 is recommended, Java 6 and 7 is no longer supported.
 
 Installing Sponge (coremod)
 ===========================

--- a/source/server/getting-started/installation.rst
+++ b/source/server/getting-started/installation.rst
@@ -11,7 +11,7 @@ the :doc:`implementations/index` page.
 
 Instructions for both are listed on this page.
 
-You will also need to :doc:`install Java <jre>`. To recap, Java 8 is recommended, Java 6 and 7 is no longer supported.
+You will also need to :doc:`install Java <jre>`. To recap, Java 8 is the minimum version required; older versions (ie Java 6 and 7) are no longer supported.
 
 Installing Sponge (coremod)
 ===========================

--- a/source/server/getting-started/jre.rst
+++ b/source/server/getting-started/jre.rst
@@ -4,8 +4,9 @@ Installing Java
 
 Java is needed to run Sponge and Minecraft. You most likely already have Java, but you may need to update it.
 
-Sponge needs Java 8 at this time. Java 7 won't work, just like Java 6 as both are deprecated versions. The difference
-between major versions of Java (6, 7, 8) is fairly significant, and older versions won't run Sponge properly.
+Sponge needs Java 8 (or newer) at this time. Older Java versions are deprecated and will not work with Sponge.
+The difference between major versions of Java (6, 7, 8) is fairly significant, and older versions cannot run
+Sponge properly.
 
 Installing Java
 ===============

--- a/source/server/getting-started/jre.rst
+++ b/source/server/getting-started/jre.rst
@@ -4,9 +4,8 @@ Installing Java
 
 Java is needed to run Sponge and Minecraft. You most likely already have Java, but you may need to update it.
 
-Sponge recommends that you install Java 8 at this time. Java 7 will work as well, but Java 6 is not recommended and may
-not work correctly. The difference between major versions of Java (6, 7, 8) is fairly significant, and newer versions
-run much better.
+Sponge needs Java 8 at this time. Java 7 won't work, just like Java 6 as both are deprecated versions. The difference
+between major versions of Java (6, 7, 8) is fairly significant, and older versions won't run Sponge properly.
 
 Installing Java
 ===============


### PR DESCRIPTION
With the recent announcement that Sponge will (finally) move to Java8 and drop support for 6 and 7 the Docs now must get updated to fit Sponge.

ToDo-list i can currently think of:
- [x] check all code snippets for validity, modify where needed
 - [x] use Java Optionals instead of Guava
 - [x] remove import of Guava
- [x] state that Sponge needs Java8 to run
- [x] modify installation insctructions for JRE and JDK to require Java 8
- [ ] add instructions for Linux, where Java 8 sometimes isn't easily available

reference: 
https://forums.spongepowered.org/t/theres-a-java-update-available/9147
Issue:  #324