### PR TITLE
Permissions for mod-added commands.

### DIFF
--- a/source/server/spongineer/commands.rst
+++ b/source/server/spongineer/commands.rst
@@ -91,14 +91,13 @@ API, such as SpongeVanilla, do not include these commands.
 ====================  ========================================  ====================
 Command               Description                               Permission
 ====================  ========================================  ====================
-/forge tps            Display ticks per second for each world.  Not yet available.
-/forge track          Enable tile entity tracking.
+/forge tps            Display ticks per second for each world.  forge.command.forge
+/forge track          Enable tile entity tracking.              forge.command.forge
 ====================  ========================================  ====================
 
 |
 
-For most Forge mods, command permissions are provided in the form ``<modid>.command.<commandname>``. This may not always
-be the case, so check the mods you use to be sure.
+For any Forge mods that use the vanilla command API, command permissions are provided in the form ``<modid>.command.<commandname>``.
 
 
 Vanilla


### PR DESCRIPTION
I have confirmed that the permissions for mod-added commands is "<modid>.command.<name>" and am updating the docs to reflect that.

Code:
```java
package jbyoshi.test;

import java.util.*;

import org.spongepowered.api.event.*;
import org.spongepowered.api.event.network.*;
import org.spongepowered.api.plugin.*;
import org.spongepowered.api.service.pagination.*;
import org.spongepowered.api.text.*;
import org.spongepowered.api.util.command.*;
import org.spongepowered.common.command.*;

@Plugin(id = "jbyoshitest", name = "JBYoshi Sponge Test", version = "1.0")
public class TestPlugin {
	@Listener
	public void go(ClientConnectionEvent.Join e) {
		Map<String, Text> texts = new TreeMap<String, Text>();
		for (CommandMapping mapping : e.getGame().getCommandDispatcher().getAll().values()) {
			CommandCallable callable = mapping.getCallable();
			if (callable instanceof MinecraftCommandWrapper) {
				MinecraftCommandWrapper cmd = (MinecraftCommandWrapper) callable;
				for (String alias : mapping.getAllAliases()) {
					texts.put(alias, Texts.of(alias, " = ", cmd.getCommandPermission()));
				}
			}
		}
		e.getGame().getServiceManager().provideUnchecked(PaginationService.class).builder()
				.title(Texts.of("Permissions")).contents(new ArrayList<Text>(texts.values()))
				.sendTo(e.getTargetEntity());
	}
}
```