### PR TITLE
[WIP] remove JD hardlinking. fixes #127

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -27,7 +27,11 @@ import sponge_docs_theme
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx.ext.extlinks']
+
+extlinks = {
+'jdpackage': ('https://jd.spongepowered.org/index.html?%s/package-summary.html',' '),
+'jd': ('https://jd.spongepowered.org/index.html?%s.html',' ')}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/source/index.rst
+++ b/source/index.rst
@@ -5,6 +5,12 @@ Sponge Documentation
 Introduction
 ============
 
+Package: :jdpackage:`org.spongepowered.data.manipulator <org/spongepowered/api/data/manipulator>`
+
+Class: :jd:`org.spongepowered.api.event.impl.AbstractEvent <org/spongepowered/api/event/impl/AbstractEvent>`
+
+Interface: :jd:`org.spongepowered.api.CatalogType <org/spongepowered/api/CatalogType>`
+
 Welcome to SpongeDocs, the official documentation for the open-source `Sponge <http://spongepowered.org>`__ project.
 
 The Sponge project currently has four main components:


### PR DESCRIPTION
This PR adds 'sphinx.ext.extlinks' module to conf.py. This allows us to add non-hardcoded javadoc links to the docs: `:javadocs:'link goes here'`

After further investigation i think that the javalink package for Sphinx is the way to go. This however requires adjustment to the current build process:
- [ ] update Sphinx to 1.3
- [ ] install sphinx-javalink + dependencies
- [ ] find a way to retrieve *.jar for the required classpath variable