### PR TITLE
add source button

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -14,6 +14,12 @@
 import sys, os
 import sponge_docs_theme
 
+# Set your Github user, repo and branch here. This will be used to link to the
+# sourcecode in the top right corner of the pages.
+github_repo = 'SpongeDocs'
+github_user = 'SpongePowered'
+github_host = 'github.com'
+github_branch = 'master'
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -93,6 +99,16 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
+
+# adds the actual variables for calling in layout.html to allow for
+# fully configurable sourcecode linking
+html_context = {
+    'github_user' : github_user,
+    'github_repo' : github_repo,
+    'source_suffix' : source_suffix,
+    'github_host' : github_host,
+    'github_branch' : github_branch
+    }
 
 # readability
 html_theme = 'sponge_docs_theme'


### PR DESCRIPTION
This PR proposes a button to access the source files on Github directly. It has to be pulled in together with SpongePowered/sponge_docs_theme#8, in order to work properly. I tried to make this as configurable as possible, so all necessary adjustments (name of the github user, repo, desired branch) can be made in conf.py of the project itself.

As i'm a Sphinx/Python novice, i'd like to get some feedback on this first, especially from @gratimax as he's the one who maintains the Docs theme.

Here's a preview of the proposed button: 
![unbenannt](https://cloud.githubusercontent.com/assets/10940670/10977985/c529b2ae-83f4-11e5-9deb-c52ea315a0ca.PNG)

