### PR TITLE
enable favicon in conf.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -124,7 +124,7 @@ html_theme_path = [sponge_docs_theme.get_html_theme_path()]
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+html_favicon = 'favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Adds a favicon to the SpongeDocs. This must be pulled in together with or after SpongePowered/Sponge_docs_theme#9 has been merged.

Note that the build will fail as long as the theme PR isn't merged.