### PR TITLE
Exploit Patch Documentation

### DIFF
--- a/source/server/management/exploit-patches.rst
+++ b/source/server/management/exploit-patches.rst
@@ -1,0 +1,30 @@
+===============
+Exploit Patches
+===============
+
+In recent Sponge builds (SpongeForge 974+), SpongeForge and SpongeVanilla patch a few client-server exploits. Whenever
+the implementations detect a user performing an exploit, they are kicked from the server with a message explaining why
+they were kicked. If enabled, a log message is also sent to the console. More exploit patches may be added in the
+future.
+
+Exploits Patched by Sponge Implementations
+==========================================
+
+#. Sign command exploit where a client could run a command such as 'op'
+#. Client could force the server to make the user respawn invisible
+#. Client could set an itemstack's display name and cause it to exceed the character limit
+
+.. warning::
+    The invisibility exploit patch has been disabled in recent Sponge builds due to the detection method falsely
+    accusing users of performing the exploit.
+
+Log Message Control
+===================
+
+Log messages for the exploit patches can be individually controlled in the Sponge config file. Please read the
+:doc:`../getting-started/configuration/sponge-conf` page for more information.
+
+.. tip::
+    Log messages can also be controlled via a command, instead of directly editing the config file. For example, to
+    enable the sign command exploit logging, type ``sponge config -g logging.exploit-sign-command-updates true`` in
+    the console (You can also type the commands in-game if you are an op).

--- a/source/server/management/index.rst
+++ b/source/server/management/index.rst
@@ -13,3 +13,4 @@ Contents
     bans
     permissions
     plugins
+    exploit-patches


### PR DESCRIPTION
Documents how Sponge patches various exploits in Vanilla Minecraft. Closes issue #402.

Depends on #413 to update the global.conf page

---

[Main Preview](http://flibio.net/preview/exploit-patches/)

[File Changed](http://flibio.net/preview/exploit-patches/server/management/exploit-patches/)