### PR TITLE
Add Java 1.8.0_40+ warnings

### DIFF
--- a/source/server/getting-started/installation.rst
+++ b/source/server/getting-started/installation.rst
@@ -8,7 +8,8 @@ the :doc:`implementations/index` page.
 
 Instructions for both are listed on this page.
 
-You will also need to :doc:`install Java <jre>`. To recap, Java 8 is the minimum version required; older versions (ie Java 6 and 7) are no longer supported.
+You will also need to :doc:`install Java <jre>`. To recap, Java 8 is the minimum version required; older versions
+(ie Java 6 and 7) are no longer supported.
 
 Installing SpongeForge
 ======================
@@ -21,9 +22,9 @@ Single Player / In-Game LAN Servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
-  When using the Mojang Minecraft installer for Windows, Mojang makes use of their own Java version and not the one one
-  you installed on your system. The installer currently ships with Java ``1.8.0_25``, note that Sponge requires
-  **at least** ``1.8.0_40`` or above to run properly. You can grab the Launcher without included Java here:
+  When using the Mojang Minecraft installer for *Windows*, Mojang makes use of their own Java version and not the one
+  you installed on your system. The installer currently ships with Java ``1.8.0_25``. Note that Sponge requires
+  **at least** ``1.8.0_40`` or above to run properly. You can grab the Windows Launcher without included Java here:
   `official Minecraft Launcher <https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.exe>`_
 
 1. Download the Minecraft Forge installer from the `Minecraft Forge website <http://files.minecraftforge.net/>`_. The

--- a/source/server/getting-started/installation.rst
+++ b/source/server/getting-started/installation.rst
@@ -22,10 +22,10 @@ Single Player / In-Game LAN Servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
-  When using the Mojang Minecraft installer for *Windows*, Mojang makes use of their own Java version and not the one
-  you installed on your system. The installer currently ships with Java ``1.8.0_25``. Note that Sponge requires
-  **at least** ``1.8.0_40`` or above to run properly. You can grab the Windows Launcher without included Java here:
-  `official Minecraft Launcher <https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.exe>`_
+  When using the Mojang installer, Mojang makes use of their own Java version and not the one you installed on your
+  system. The installer currently ships with Java ``1.8.0_25`` for Windows and ``1.8.0_60`` for OSX. Note that Sponge
+  requires **at least** ``1.8.0_40`` or above to run properly. You can grab the Launcher without included Java here:
+  `official Minecraft Launcher <https://minecraft.net/download>`_
 
 1. Download the Minecraft Forge installer from the `Minecraft Forge website <http://files.minecraftforge.net/>`_. The
    latest version, or any version that's newer than the one listed :doc:`in the filename of the Sponge download

--- a/source/server/getting-started/installation.rst
+++ b/source/server/getting-started/installation.rst
@@ -20,6 +20,12 @@ Installing SpongeForge
 Single Player / In-Game LAN Servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+  When using the Mojang Minecraft installer for Windows, Mojang makes use of their own Java version and not the one one
+  you installed on your system. The installer currently ships with Java ``1.8.0_25``, note that Sponge requires
+  **at least** ``1.8.0_40`` or above to run properly. You can grab the Launcher without included Java here:
+  `official Minecraft Launcher <https://s3.amazonaws.com/Minecraft.Download/launcher/Minecraft.exe>`_
+
 1. Download the Minecraft Forge installer from the `Minecraft Forge website <http://files.minecraftforge.net/>`_. The
    latest version, or any version that's newer than the one listed :doc:`in the filename of the Sponge download
    <implementations/spongeforge>`, should work.

--- a/source/server/getting-started/jre.rst
+++ b/source/server/getting-started/jre.rst
@@ -5,8 +5,8 @@ Installing Java
 Java is needed to run Sponge and Minecraft. You most likely already have Java, but you may need to update it.
 
 Sponge requires Java 8 (specifically ``1.8.0_40`` or above) at this time. Older Java versions are deprecated and will not
-work with Sponge. The difference between major versions of Java (6, 7, 8) is fairly significant, and older versions
-cannot run Sponge properly.
+work with Sponge. The difference between major versions of Java (6, 7, 8) is significant, and older versions cannot run
+Sponge properly.
 
 Installing Java
 ===============

--- a/source/server/getting-started/jre.rst
+++ b/source/server/getting-started/jre.rst
@@ -4,9 +4,9 @@ Installing Java
 
 Java is needed to run Sponge and Minecraft. You most likely already have Java, but you may need to update it.
 
-Sponge needs Java 8 (or newer) at this time. Older Java versions are deprecated and will not work with Sponge.
-The difference between major versions of Java (6, 7, 8) is fairly significant, and older versions cannot run
-Sponge properly.
+Sponge needs Java 8 (specifically ``1.8.0_40`` or above) at this time. Older Java versions are deprecated and will not
+work with Sponge. The difference between major versions of Java (6, 7, 8) is fairly significant, and older versions
+cannot run Sponge properly.
 
 Installing Java
 ===============

--- a/source/server/getting-started/jre.rst
+++ b/source/server/getting-started/jre.rst
@@ -4,7 +4,7 @@ Installing Java
 
 Java is needed to run Sponge and Minecraft. You most likely already have Java, but you may need to update it.
 
-Sponge needs Java 8 (specifically ``1.8.0_40`` or above) at this time. Older Java versions are deprecated and will not
+Sponge requires Java 8 (specifically ``1.8.0_40`` or above) at this time. Older Java versions are deprecated and will not
 work with Sponge. The difference between major versions of Java (6, 7, 8) is fairly significant, and older versions
 cannot run Sponge properly.
 


### PR DESCRIPTION
* add warning about Mojang shipping 1.8.0_25 with their Windows Launcher
* set required Java version to 1.8.0_40+