### PR TITLE
Fix instructions regarding the Forge version required

### DIFF
--- a/source/server/getting-started/implementations/spongeforge.rst
+++ b/source/server/getting-started/implementations/spongeforge.rst
@@ -15,11 +15,15 @@ Check :doc:`../../../downloads` for further information.
 Reading the Download Filename
 =============================
 
-When you download SpongeForge, the name of the file will provide some important version information.
+When you download SpongeForge, the name of the file will provide some important version information. It includes a
+Forge build number which this version of SpongeForge is compatible with. Other builds, even ones differing by only a
+few build numbers are not supported.
 
-The format of the filename is ``{MCVersion}-{ForgeVersion}-{SpongeAPIVersion}{SpongeBuildId}``
+However, SpongeForge usually updates to a new Forge build fairly soon after it's released, so you needn't
+worry about always having to run an outdated Forge version in order to use SpongeForge.
 
-Note that there is no separator between the Sponge API Version and the Sponge Build ID.
+
+The format of the filename is ``spongeforge-{MCVersion}-{ForgeVersion}-{SpongeAPIVersion}-{SpongeBuildId}``
 
 +----------------------+----------------------------------------------------------------------------------------------+
 | ``MCVersion``        | The minecraft version. Only clients compatible with this version can connect.                |
@@ -36,8 +40,15 @@ Note that there is no separator between the Sponge API Version and the Sponge Bu
 Example
 ~~~~~~~
 
-For example the file name ``1.8-1371-2.1DEV-439`` tells us that this SpongeForge version is compatible to Minecraft ``1.8``,
-best used with Forge version ``1371``, provides the API Version ``2.1`` and has the build id ``Dev-439``
+The file name ``spongeforge-1.8-1577-3.0.0-BETA-1000.jar`` is compatible with minecraft version 1.8, requires build
+``1.8-11.14.4.1577`` of Forge, provides SpongeAPI v3.0.0 and was the 1000th build of SpongeForge.
+
+.. note::
+
+    Normal Forge mods can usually run on any build of Forge for a given minecraft version (e.g. 1.8.0) without
+    any problems. However, SpongeForge needs to access, among other things, internal parts of Forge, which
+    most mods shouldn't be touching, let alone modifying as Sponge does. Since Forge is free to change internal
+    code whenever they want to, its normal guarantee of backwards-compatibility doesn't apply to SpongeForge.
 
 Links
 =====

--- a/source/server/getting-started/installation.rst
+++ b/source/server/getting-started/installation.rst
@@ -4,9 +4,7 @@ Installing Sponge
 
 Recall that there are two official variants of Sponge (SpongeForge and SpongeVanilla) — they both run Sponge plugins
 identically (that's the goal), but how either work behind the scenes (the code) differs. This is better explained in
-the :doc:`implementations/index` page.
-
-Instructions for both are listed on this page.
+the :doc:`implementations/index` page. Instructions for both are listed on this page.
 
 You will also need to :doc:`install Java <jre>`. To recap, Java 8 is the minimum version required; older versions
 (ie Java 6 and 7) are no longer supported.
@@ -18,8 +16,6 @@ Installing SpongeForge
 
     If you use (or are planning to use) a game server host, they may have a control panel that can install Sponge for you.
 
-Single Player / In-Game LAN Servers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
   When using the Mojang installer, Mojang makes use of their own Java version and not the one you installed on your
@@ -27,9 +23,12 @@ Single Player / In-Game LAN Servers
   requires **at least** ``1.8.0_40`` or above to run properly. You can grab the Launcher without included Java here:
   `official Minecraft Launcher <https://minecraft.net/download>`_
 
-1. Download the Minecraft Forge installer from the `Minecraft Forge website <http://files.minecraftforge.net/>`_. The
-   latest version, or any version that's newer than the one listed :doc:`in the filename of the Sponge download
-   <implementations/spongeforge>`, should work.
+Single Player / In-Game LAN Servers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1. Download the Minecraft Forge installer from the `Minecraft Forge website <http://files.minecraftforge.net/>`_. Make
+   sure to use **exactly the same build number** as :doc:`the one listed in the filename of the Sponge download
+   <implementations/spongeforge>`.
 #. Run the provided Forge installer. A new Forge profile will be created in the Minecraft launcher.
 #. Open the Minecraft launcher, and select the new Forge profile.
 #. Click "Options" and click "Open Game Dir".


### PR DESCRIPTION
Currently, the docs state that any version newer than the one in the `SpongeForge` jar name should work. However, only the exact build number specified is supported.

This PR fixes the installation instructions to reflect the fact that only a specific Forge build is supported, and adds a short note explaining why.