### PR TITLE
Better item docs

### DIFF
--- a/source/plugin/entities/spawning.rst
+++ b/source/plugin/entities/spawning.rst
@@ -12,7 +12,8 @@ For example, let's try to spawn a Creeper:
 
     import org.spongepowered.api.entity.Entity;
     import org.spongepowered.api.entity.EntityTypes;
-    import org.spongepowered.api.event.cause.entity.spawn.SpawnCause;
+    import org.spongepowered.api.event.cause.Cause;
+    import org.spongepowered.api.event.cause.entity.spawn.EntitySpawnCause;
     import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
     import org.spongepowered.api.world.Location;
     import org.spongepowered.api.world.World;
@@ -40,3 +41,13 @@ The ``createEntity()`` method returns an ``Optional`` as the ``Location`` may no
 ``Entity`` into the world. We will need to specify a ``Cause`` for the spawning. For spawning ``Entity``\ s, it is best to
 use ``EntitySpawnCause``. In this example, we stated that our entity was spawned from a plugin, however we can make it
 any cause that best describes why we are spawning this in, such as a mob spawner, or spawn egg.
+
+.. warning::
+
+    Note that as of API 3.0, ``SpawnCause`` is NOT implemented. Until then, you will need to specify some other cause,
+    such as a ``CommandSource`` or a ``Player``. If you cannot find one that would suit your needs, simply specify your
+    main plugin instance as the ``Cause``. Here is an example of specifying a ``CommandSource`` as the ``Cause``:
+
+    ``extent.spawnEntity(item, Cause.of(src));``
+    
+    Take a look at the :doc:`cause documentation <../event/causes>` for more information.

--- a/source/plugin/index.rst
+++ b/source/plugin/index.rst
@@ -39,7 +39,7 @@ Contents
     data/index
     blocks/index
     entities/index
-    items
+    items/index
     injection
     scheduler
     database

--- a/source/plugin/items/creating.rst
+++ b/source/plugin/items/creating.rst
@@ -1,0 +1,50 @@
+=====================
+Creating an ItemStack
+=====================
+
+Let's create a Diamond Sword:
+
+.. code-block:: java
+
+    import com.google.inject.Inject;
+    import org.spongepowered.api.Game;
+    import org.spongepowered.api.data.key.Keys;
+    import org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData;
+    import org.spongepowered.api.data.meta.ItemEnchantment;
+    import org.spongepowered.api.item.Enchantment;
+    import org.spongepowered.api.item.ItemTypes;
+    import org.spongepowered.api.item.inventory.ItemStack;
+    import org.spongepowered.api.text.Texts;
+    import org.spongepowered.api.text.format.TextColors;
+
+    import java.util.List;
+    import java.util.stream.Collectors;
+
+    public class GenerateSword {
+
+        @Inject private Game game;
+
+        public ItemStack generateItem() {
+            ItemStack.Builder builder = this.game.getRegistry().createBuilder(ItemStack.Builder.class);
+            ItemStack superMegaAwesomeSword = builder.itemType(ItemTypes.DIAMOND_SWORD).build();
+
+            // Let's just give all sorts of enchantments here.
+            EnchantmentData enchantmentData = superMegaAwesomeSword.getOrCreate(EnchantmentData.class).get();
+            final List<Enchantment> enchantments = this.game.getRegistry().getAllOf(Enchantment.class).stream().collect(Collectors.toList());
+            for (Enchantment enchantment : enchantments) {
+                enchantmentData.set(enchantmentData.enchantments().add(new ItemEnchantment(enchantment, 1000)));
+            }
+            superMegaAwesomeSword.offer(enchantmentData);
+
+            // Oh! We haven't given it a name...
+            superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, Texts.of(TextColors.BLUE, "SUPER", TextColors.GOLD, "MEGA", TextColors.DARK_AQUA, "AWESOME", TextColors.AQUA, " Diamond Sword"));
+
+            superMegaAwesomeSword.offer(Keys.UNBREAKABLE, true);
+
+            return superMegaAwesomeSword;
+        }
+
+    }
+
+
+The code above will generate a diamond sword with all available enchantments and the colored display of "SUPERMEGAAWESOME Diamond Sword".

--- a/source/plugin/items/creating.rst
+++ b/source/plugin/items/creating.rst
@@ -71,7 +71,7 @@ Finally we want it to be unbreakable:
 That's it. you now have a fully enchanted, unbreakable and beautifully named sword which you can spawn or give to
 players. The sword goes by the name "SUPERMEGAAWESOME Diamond Sword".
 
-If you're still unsure how the complete example looks, this is for you:
+If you're still unsure how the complete example looks, here's the final result:
 
 
 .. code-block:: java

--- a/source/plugin/items/creating.rst
+++ b/source/plugin/items/creating.rst
@@ -2,116 +2,129 @@
 Creating an ItemStack
 =====================
 
-If you want to create your own Items, you need to go through several steps. Let's go through a basic example and create
-an enchanted diamond sword. We start with our imports:
+If you want to create your own items, you need to go through several steps. Let's go through a basic example and create
+an enchanted diamond sword.
+
+To create an ``ItemStack``, we need to first grab the builder from the ``ItemStack``. This is done with the
+``ItemStack.builder()`` method. In the builder, we can specify things such as the ``ItemType`` or the quantity of the
+item. In our example, we will be creating a diamond sword that contains enchantments, a custom name, and is
+unbreakable. If you want a plain sword without any other data, then this is all you need to do:
 
 .. code-block:: java
 
-    import com.google.inject.Inject;
-    import org.spongepowered.api.Game;
-    import org.spongepowered.api.data.key.Keys;
-    import org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData;
-    import org.spongepowered.api.data.meta.ItemEnchantment;
-    import org.spongepowered.api.item.Enchantment;
     import org.spongepowered.api.item.ItemTypes;
     import org.spongepowered.api.item.inventory.ItemStack;
-    import org.spongepowered.api.text.Texts;
-    import org.spongepowered.api.text.format.TextColors;
+
+    public ItemStack generateSword() {
+        ItemStack superMegaAwesomeSword = ItemStack.builder()
+            .itemType(ItemTypes.DIAMOND_SWORD).build();
+        return superMegaAwesomeSword;
+    }
+
+Creating the basic item is done. Now this is a normal diamond sword that we created, but what if we wanted something
+more interesting? What about enchanting and naming our sword? We can use ``EnchantmentData`` to give our sword some
+enchantments. The following example will give our sword every enchantment in the game, to level 1000. Make sure to
+include this all before ``return superMegaAwesomeSword;``.
+
+.. code-block:: java
 
     import java.util.List;
     import java.util.stream.Collectors;
 
-Alright. The first step is done now. Next up is the ``ItemStack.Builder``, it will create the unenchanted sword for us.
-If you don't want to enchant anything, or don't want to give it a beautiful name, then you're almost done.
+    import org.spongepowered.api.Sponge;
+    import org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData;
+    import org.spongepowered.api.data.meta.ItemEnchantment
+    import org.spongepowered.api.item.Enchantment;
 
-.. code-block:: java
+    EnchantmentData enchantmentData = superMegaAwesomeSword
+        .getOrCreate(EnchantmentData.class).get();
+    final List<Enchantment> enchantments = Sponge.getRegistry()
+        .getAllOf(Enchantment.class).stream().collect(Collectors.toList());
 
-    public class GenerateSword {
-
-        @Inject private Game game;
-
-        public ItemStack generateItem() {
-            ItemStack.Builder builder = this.game.getRegistry().createBuilder(ItemStack.Builder.class);
-            ItemStack superMegaAwesomeSword = builder.itemType(ItemTypes.DIAMOND_SWORD).build();
-
-            // Include enchantments or naming here
-
-            return superMegaAwesomeSword;
-        }
-
-    }
-
-Now the basic item is done. So what about enchanting and naming, you ask? Here we go! Include this before
-``return superMegaAwesomeSword();`` to enchant the sword:
-
-.. code-block:: java
-
-    // Let's just give all sorts of enchantments here.
-    EnchantmentData enchantmentData = superMegaAwesomeSword.getOrCreate(EnchantmentData.class).get();
-    final List<Enchantment> enchantments = this.game.getRegistry().getAllOf(Enchantment.class).stream().collect(Collectors.toList());
     for (Enchantment enchantment : enchantments) {
-        enchantmentData.set(enchantmentData.enchantments().add(new ItemEnchantment(enchantment, 1000)));
+        enchantmentData.set(enchantmentData.enchantments()
+            .add(new ItemEnchantment(enchantment, 1000)));
     }
     superMegaAwesomeSword.offer(enchantmentData);
 
-And this is the code to give it a beatiful name:
+Now let's say we wanted to give our overpowered sword a cool name to go with it. Here, we can directly offer a key to
+the ``ItemStack``. Using this key, we can change the name of the ``ItemStack`` to "SUPER MEGA AWESOME Diamond Sword"
 
 .. code-block:: java
 
-    // Oh! We haven't given it a name...
-    superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, Texts.of(TextColors.BLUE, "SUPER", TextColors.GOLD, "MEGA", TextColors.DARK_AQUA, "AWESOME", TextColors.AQUA, " Diamond Sword"));
-
-Finally we want it to be unbreakable:
-
-.. code-block:: java
-
-    //make the sword unbreakable
-    superMegaAwesomeSword.offer(Keys.UNBREAKABLE, true);
-
-That's it. you now have a fully enchanted, unbreakable and beautifully named sword which you can spawn or give to
-players. The sword goes by the name "SUPERMEGAAWESOME Diamond Sword".
-
-If you're still unsure how the complete example looks, here's the final result:
-
-
-.. code-block:: java
-
-    import com.google.inject.Inject;
-    import org.spongepowered.api.Game;
     import org.spongepowered.api.data.key.Keys;
-    import org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData;
-    import org.spongepowered.api.data.meta.ItemEnchantment;
-    import org.spongepowered.api.item.Enchantment;
-    import org.spongepowered.api.item.ItemTypes;
-    import org.spongepowered.api.item.inventory.ItemStack;
-    import org.spongepowered.api.text.Texts;
+    import org.spongepowered.api.text.Text;
     import org.spongepowered.api.text.format.TextColors;
 
-    import java.util.List;
-    import java.util.stream.Collectors;
+    superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, Text.of(
+        TextColors.BLUE, "SUPER ",
+        TextColors.GOLD, "MEGA ",
+        TextColors.DARK_AQUA, "AWESOME ",
+        TextColors.AQUA, "Diamond Sword"));
 
-    public class GenerateSword {
+Finally, to make the sword unbreakable, we can use keys again:
 
-        @Inject private Game game;
+.. code-block:: java
 
-        public ItemStack generateItem() {
-            ItemStack.Builder builder = this.game.getRegistry().createBuilder(ItemStack.Builder.class);
-            ItemStack superMegaAwesomeSword = builder.itemType(ItemTypes.DIAMOND_SWORD).build();
+    superMegaAwesomeSword.offer(Keys.UNBREAKABLE, true);
 
-            // Let's just give all sorts of enchantments here.
-            EnchantmentData enchantmentData = superMegaAwesomeSword.getOrCreate(EnchantmentData.class).get();
-            final List<Enchantment> enchantments = this.game.getRegistry().getAllOf(Enchantment.class).stream().collect(Collectors.toList());
-            for (Enchantment enchantment : enchantments) {
-                enchantmentData.set(enchantmentData.enchantments().add(new ItemEnchantment(enchantment, 1000)));
-            }
-            superMegaAwesomeSword.offer(enchantmentData);
+That's it. You now have a fully enchanted, unbreakable, and beautifully named sword which you can give to players.
 
-            // Oh! We haven't given it a name...
-            superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, Texts.of(TextColors.BLUE, "SUPER", TextColors.GOLD, "MEGA", TextColors.DARK_AQUA, "AWESOME", TextColors.AQUA, " Diamond Sword"));
-            //make the sword unbreakable
-            superMegaAwesomeSword.offer(Keys.UNBREAKABLE, true);
+Spawning the Item
+=================
+Sure we can simply put the sword into a player's inventory, but what if we wanted to throw it out into the open world
+and spawn the item? This is where :doc:`entity spawning <../entities/spawning>` comes into play. Since the in-game
+graphical representation of an ``ItemStack`` is ``Item``, we can spawn it in similarly to a normal ``Entity``. The
+``EntityType`` will simply be ``EntityTypes.ITEM`` and we will need to specify that the ``Entity`` will represent our
+``ItemStack``. This can be done using the ``REPRESENTED_ITEM`` key. An example is shown below:
 
-            return superMegaAwesomeSword;
+.. code-block:: java
+
+    import org.spongepowered.api.entity.Entity;
+    import org.spongepowered.api.entity.EntityTypes;
+    import org.spongepowered.api.event.cause.Cause;
+    import org.spongepowered.api.event.cause.entity.spawn.EntitySpawnCause;
+    import org.spongepowered.api.event.cause.entity.spawn.SpawnTypes;
+    import org.spongepowered.api.world.Location;
+    import org.spongepowered.api.world.World;
+    import org.spongepowered.api.world.extent.Extent;
+
+    import java.util.Optional;
+    
+    public void spawnItem(ItemStack superMegaAwesomeSword, Location<World> spawnLocation) {
+        Extent extent = spawnLocation.getExtent();
+        Optional<Entity> optional = extent
+            .createEntity(EntityTypes.ITEM, spawnLocation.getPosition());
+        if (optional.isPresent()) {
+            Entity item = optional.get();
+            item.offer(Keys.REPRESENTED_ITEM, superMegaAwesomeSword.createSnapshot());
+            extent.spawnEntity(item, Cause.of(EntitySpawnCause.builder()
+                .entity(item).type(SpawnTypes.PLUGIN).build()));
         }
+    }
 
+.. warning::
+    
+    Note that as of API 3.0, ``SpawnCause`` is NOT implemented. Until then, you will need to specify some other cause,
+    such as a ``CommandSource`` or a ``Player``. If you cannot find one that would suit your needs, simply specify your
+    main plugin instance as the ``Cause``. Here is an example of specifying a ``CommandSource`` as the ``Cause``:
+
+    ``extent.spawnEntity(item, Cause.of(src));``
+    
+    Take a look at the :doc:`cause documentation <../event/causes>` for more information.
+
+Creating an ItemStack From a Block
+==================================
+
+An ``ItemStack`` for a block can be created by using the method ``itemType()`` on the builder similarly to normal
+items, but what if we wanted to create an ``ItemStack`` from a ``BlockState`` itself? To create an ``ItemStack`` from a
+``BlockState``, you would need to use the ``fromBlockState()`` method on the ``ItemStack`` builder. An example of this
+is shown below:
+
+.. code-block:: java
+
+    import org.spongepowered.api.block.BlockState;
+
+    public ItemStack createStack(BlockState state) {
+        return ItemStack.builder().fromBlockState(state).build();
     }

--- a/source/plugin/items/creating.rst
+++ b/source/plugin/items/creating.rst
@@ -2,7 +2,77 @@
 Creating an ItemStack
 =====================
 
-Let's create a Diamond Sword:
+If you want to create your own Items, you need to go through several steps. Let's go through a basic example and create
+an enchanted diamond sword. We start with our imports:
+
+.. code-block:: java
+
+    import com.google.inject.Inject;
+    import org.spongepowered.api.Game;
+    import org.spongepowered.api.data.key.Keys;
+    import org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData;
+    import org.spongepowered.api.data.meta.ItemEnchantment;
+    import org.spongepowered.api.item.Enchantment;
+    import org.spongepowered.api.item.ItemTypes;
+    import org.spongepowered.api.item.inventory.ItemStack;
+    import org.spongepowered.api.text.Texts;
+    import org.spongepowered.api.text.format.TextColors;
+
+    import java.util.List;
+    import java.util.stream.Collectors;
+
+Alright. The first step is done now. Next up is the ``ItemStack.Builder``, it will create the unenchanted sword for us.
+If you don't want to enchant anything, or don't want to give it a beautiful name, then you're almost done.
+
+.. code-block:: java
+
+    public class GenerateSword {
+
+        @Inject private Game game;
+
+        public ItemStack generateItem() {
+            ItemStack.Builder builder = this.game.getRegistry().createBuilder(ItemStack.Builder.class);
+            ItemStack superMegaAwesomeSword = builder.itemType(ItemTypes.DIAMOND_SWORD).build();
+
+            // Include enchantments or naming here
+
+            return superMegaAwesomeSword;
+        }
+
+    }
+
+Now the basic item is done. So what about enchanting and naming, you ask? Here we go! Include this before
+``return superMegaAwesomeSword();`` to enchant the sword:
+
+.. code-block:: java
+
+    // Let's just give all sorts of enchantments here.
+    EnchantmentData enchantmentData = superMegaAwesomeSword.getOrCreate(EnchantmentData.class).get();
+    final List<Enchantment> enchantments = this.game.getRegistry().getAllOf(Enchantment.class).stream().collect(Collectors.toList());
+    for (Enchantment enchantment : enchantments) {
+        enchantmentData.set(enchantmentData.enchantments().add(new ItemEnchantment(enchantment, 1000)));
+    }
+    superMegaAwesomeSword.offer(enchantmentData);
+
+And this is the code to give it a beatiful name:
+
+.. code-block:: java
+
+    // Oh! We haven't given it a name...
+    superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, Texts.of(TextColors.BLUE, "SUPER", TextColors.GOLD, "MEGA", TextColors.DARK_AQUA, "AWESOME", TextColors.AQUA, " Diamond Sword"));
+
+Finally we want it to be unbreakable:
+
+.. code-block:: java
+
+    //make the sword unbreakable
+    superMegaAwesomeSword.offer(Keys.UNBREAKABLE, true);
+
+That's it. you now have a fully enchanted, unbreakable and beautifully named sword which you can spawn or give to
+players. The sword goes by the name "SUPERMEGAAWESOME Diamond Sword".
+
+If you're still unsure how the complete example looks, this is for you:
+
 
 .. code-block:: java
 
@@ -38,13 +108,10 @@ Let's create a Diamond Sword:
 
             // Oh! We haven't given it a name...
             superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, Texts.of(TextColors.BLUE, "SUPER", TextColors.GOLD, "MEGA", TextColors.DARK_AQUA, "AWESOME", TextColors.AQUA, " Diamond Sword"));
-
+            //make the sword unbreakable
             superMegaAwesomeSword.offer(Keys.UNBREAKABLE, true);
 
             return superMegaAwesomeSword;
         }
 
     }
-
-
-The code above will generate a diamond sword with all available enchantments and the colored display of "SUPERMEGAAWESOME Diamond Sword".

--- a/source/plugin/items/index.rst
+++ b/source/plugin/items/index.rst
@@ -2,7 +2,8 @@
 Working with Items
 ==================
 
-// todo
+Items are a fundamental feature of Minecraft and plugins. This section shows some basic usage examples and how to
+create your own items.
 
 
 
@@ -10,4 +11,5 @@ Working with Items
     :maxdepth: 2
     :titlesonly:
 
+    usage
     creating

--- a/source/plugin/items/index.rst
+++ b/source/plugin/items/index.rst
@@ -1,0 +1,13 @@
+==================
+Working with Items
+==================
+
+// todo
+
+
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    creating

--- a/source/plugin/items/usage.rst
+++ b/source/plugin/items/usage.rst
@@ -5,7 +5,7 @@ Basic Item Usage
 Items are represented through an ``ItemStack``. An ``ItemStack`` is an inventory item with information such as the
 amount of the item in the stack, the type of the item, and extra data such as durability. An ``Item`` itself is the
 graphical representation of an ``ItemStack`` as an entity. Be aware that you'll always get a copy and *not* the actual
-``ItemStack``.
+``ItemStack`` and thus, you will need to set it back into an inventory if desired.
 
 Checking an Item's Type
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,7 +51,6 @@ need to specify a ``List`` of ``Text`` rather than an boolean or other value. It
 see if the key can actually apply to the item. For example, some items might not have durability or may already have
 lore applied to the item.
 
-
 .. code-block:: java
 
     import org.spongepowered.api.text.Text;
@@ -59,15 +58,15 @@ lore applied to the item.
     import java.util.List;
 
     public void setLore(ItemStack stack, List<Text> itemLore) {
-        if(item.get(Keys.ITEM_LORE).isPresent()) {
-            item.offer(Keys.ITEM_LORE, itemLore);
+        if (stack.get(Keys.ITEM_LORE).isPresent()) {
+            stack.offer(Keys.ITEM_LORE, itemLore);
         }
     }
 
 Item Properties
 ~~~~~~~~~~~~~~~
 
-Certain items can contain specific properties. For example, certain items can mine specific blocks, such as a diamond
+Certain items may hold specific properties. For example, certain items can mine specific blocks, such as a diamond
 pickaxe to obsidian. Properties are used for determining if an item can cause an action without actually checking up
 the type of the item. We can check if a block can mine obsidian by using the ``HarvestingProperty`` of that item.
 
@@ -78,20 +77,19 @@ the type of the item. We can check if a block can mine obsidian by using the ``H
 
     import java.util.Optional;
 
-    public boolean canMineObsidian(ItemStack item) {
+    public boolean canMineObsidian(ItemStack stack) {
         Optional<HarvestingProperty> optional =
-            item.getProperty(HarvestingProperty.class);
+            stack.getProperty(HarvestingProperty.class);
 
-        if(optional.isPresent()) {
+        if (optional.isPresent()) {
             HarvestingProperty property = optional.get();
             return property.getValue().contains(BlockTypes.OBSIDIAN);
         }
         return false;
     }
 
-This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If it does then it will return
-if this item can harvest obsidian without even needing to check the type of the item.
+This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If present, it will then
+return if this item can harvest obsidian without the need to check the type of the item. This is useful in the event
+that a mod or a Minecraft update adds a new tool with the capabilities of mining obsidian.
 
-.. note::
-    If you need to hold data of something that isn't covered by the API, such as mod data, you need to implement the
-    ``DataTranslator`` interface to translate it to a ``DataContainer`` to be used with the rest of the API.
+.. TODO Link to docs on custom datamaipulators

--- a/source/plugin/items/usage.rst
+++ b/source/plugin/items/usage.rst
@@ -1,6 +1,6 @@
-==================
-Working with Items
-==================
+================
+Basic Item Usage
+================
 
 Items are represented through an ``ItemStack``. An ``ItemStack`` is an inventory item with information such as the
 amount of the item in the stack, the type of the item, and extra data such as durability. An ``Item`` itself is the
@@ -50,6 +50,7 @@ need to specify a ``List`` of ``Text`` rather than an boolean or other value. It
 see if the key can actually apply to the item. For example, some items might not have durability or may already have
 lore applied to the item.
 
+
 .. code-block:: java
 
     import org.spongepowered.api.text.Text;
@@ -87,9 +88,18 @@ the type of the item. We can check if a block can mine obsidian by using the ``H
         return false;
     }
 
+<<<<<<< ed196e3d3a276dc7fb6a2d76b7bec29161cfac5c:source/plugin/items.rst
 This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If it does then it will return
 if this item can harvest obsidian without even needing to check the type of the item.
 
 .. note::
     If you need to hold data of something that isn't covered by the API, such as mod data, you need to implement the
     ``DataTranslator`` interface to translate it to a ``DataContainer`` to be used with the rest of the API.
+=======
+This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If it does then it will
+return if this item can harvest obsidian without even needing to check the type of the item.
+
+.. note::
+    If you need to hold data of something that isn't covered by the API, such as mod data, you need to implement
+    the ``DataTranslator`` interface to translate it to a ``DataContainer`` to be used with the rest of the API.
+>>>>>>> add explanations:source/plugin/items/usage.rst

--- a/source/plugin/items/usage.rst
+++ b/source/plugin/items/usage.rst
@@ -4,7 +4,8 @@ Basic Item Usage
 
 Items are represented through an ``ItemStack``. An ``ItemStack`` is an inventory item with information such as the
 amount of the item in the stack, the type of the item, and extra data such as durability. An ``Item`` itself is the
-graphical representation of an ``ItemStack`` as an entity.
+graphical representation of an ``ItemStack`` as an entity. Be aware that you'll always get a copy and *not* the actual
+``ItemStack``.
 
 Checking an Item's Type
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -88,18 +89,9 @@ the type of the item. We can check if a block can mine obsidian by using the ``H
         return false;
     }
 
-<<<<<<< ed196e3d3a276dc7fb6a2d76b7bec29161cfac5c:source/plugin/items.rst
 This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If it does then it will return
 if this item can harvest obsidian without even needing to check the type of the item.
 
 .. note::
     If you need to hold data of something that isn't covered by the API, such as mod data, you need to implement the
     ``DataTranslator`` interface to translate it to a ``DataContainer`` to be used with the rest of the API.
-=======
-This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If it does then it will
-return if this item can harvest obsidian without even needing to check the type of the item.
-
-.. note::
-    If you need to hold data of something that isn't covered by the API, such as mod data, you need to implement
-    the ``DataTranslator`` interface to translate it to a ``DataContainer`` to be used with the rest of the API.
->>>>>>> add explanations:source/plugin/items/usage.rst


### PR DESCRIPTION
Expands on the previously basic item docs. Now includes creating an `ItemStack`, spawning an `ItemStack` through an `Item` entity, and creating an `ItemStack` from a `BlockState`. If there is anything else that should be added, point such out.