### PR TITLE
Purge docs.spongepowered.org cache on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ notifications:
   email: false
 env:
   global:
-  - secure: eqEdHuWpxExydgV9CrTwGF9UiVX+rTzOWN9Yru9yjmaoYate44h4p7a8GtxwAHL3wFOycmmF1Q3Ygezzly2GvubOwFDKE6R7wb+Me7Zkt9IUCOczsHQoWw6voZN1pgJYJU13kZMaDfonqheVrXDNx6dJY3pCxIZCnZvhUBcMX0M=
+  - secure: "eqEdHuWpxExydgV9CrTwGF9UiVX+rTzOWN9Yru9yjmaoYate44h4p7a8GtxwAHL3wFOycmmF1Q3Ygezzly2GvubOwFDKE6R7wb+Me7Zkt9IUCOczsHQoWw6voZN1pgJYJU13kZMaDfonqheVrXDNx6dJY3pCxIZCnZvhUBcMX0M="
+  - secure: "KKQfrtg1UUepRdHLiqjRkEJTSc/p4ovhNTK+kSyAFseMF7YwwbIOO9rkouJfJwzqMcXu2vPim8assHWrrsnG5GHMUDscNEOyqwF7Pp2d+LS+xitkBOScVhvorteRCRSxGyR0QX5GjDBsCJBvsh5GW/GY7a+SSxwle0s4pph1+gc="

--- a/etc/docs.sh
+++ b/etc/docs.sh
@@ -122,4 +122,13 @@ cp -R ./dist/. deploy/
 cd deploy
 git add .
 git commit -q -m "Deploy $(date)" &> /dev/null
-git push -q -f origin gh-pages &> /dev/null
+git push -q -f origin gh-pages &> /dev/null || exit $?
+
+if [[ -n "$FASTLY_API_KEY" ]]; then
+     echo Performing instant purge of docs.spongepowered.org
+     curl -s -H "Fastly-Key: ${FASTLY_API_KEY}" -H "Accept: application/json" -X POST -d '' "https://api.fastly.com/service/${FASTLY_API_SERVICE}/purge_all" 2>/dev/null
+     # this echo needed since JSON doesn't terminate with newline, and I want a newline here
+     echo
+else
+     echo Unable to purge; FASTLY_API_KEY or FASTLY_API_SERVICE not set
+fi


### PR DESCRIPTION
We should purge the docs.spongepowered.org cache on deploy to make sure we're not serving anyone stale content.