### PR TITLE
Add link to a separate assets repository

### DIFF
--- a/source/about/assets.rst
+++ b/source/about/assets.rst
@@ -2,8 +2,8 @@
 Art Assets
 ==========
 
-This page provides the official SpongePowered logo and mascot. Feel free to use them to spread the word about Sponge.
-However note that these images are **not** provided under the MIT License.
+This page provides links to the official SpongePowered logo and mascot. Feel free to use them to spread the word about
+Sponge. However note that these images are **not** provided under the MIT License.
 
 .. note::
   If you're reading a translated version, please note that the English license is the one which counts. Translated
@@ -37,16 +37,8 @@ You may not:
 * Change any colors or dimensions.
 
 
-The Official Sponge Logo
-~~~~~~~~~~~~~~~~~~~~~~~~
+The Official Sponge Art Assets Repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. image:: /images/logo-spongepowered.png
-    :align: center
-    :alt: official SpongePowered logo
-
-Spongie - The Official Sponge Mascot
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. image:: /images/logo-spongie.png
-    :align: center
-    :alt: Spongie the SpongePowered mascot
+In the future all Sponge related assets are available on our assets repository. You'll find it here: 
+`Official SpongePowered Art Assets Repository <https://github.com/SpongePowered/SpongeAssets/>`_

--- a/source/about/assets.rst
+++ b/source/about/assets.rst
@@ -2,8 +2,9 @@
 Art Assets
 ==========
 
-This page provides links to the official SpongePowered logo and mascot. Feel free to use them to spread the word about
-Sponge. However note that these images are **not** provided under the MIT License.
+This page provides links to the official SpongePowered logo and mascot. The font used in the logo is *Montserrat*.
+Feel free to use them to spread the word about Sponge. However, please note that these images are **not** provided
+under the MIT License.
 
 .. note::
   If you're reading a translated version, please note that the English license is the one which counts. Translated
@@ -12,27 +13,29 @@ Sponge. However note that these images are **not** provided under the MIT Licens
 You may:
 
 * Make minor modifications to Spongie’s facial expressions - such as making a cute smile,
-  making them perplexed or sad, adding a hat, and so on. It should be easily recognizable that the Spongie you create
+  making her perplexed or sad, adding a hat, and so on. It should be easily recognizable that the Spongie you create
   is the Spongie mascot, but wearing a different expression or clothing.
 
 * Use Spongie or the SpongePowered logo in an article or blog post about the Sponge project, and to spread the word.
 
 * Use the Spongepowered Logo to link to `Sponge Homepage <http://spongepowered.org>`__
-  (for example in your signature on forums etc.)
+  (for example in your signature on forums etc.) or other official SpongePowered resources.
+
+* Use the logos in social buttons.
 
 You may not:
 
 * Use the mascot as a link to the Sponge project only. The SpongePowered logo (which retains Spongie’s form) is a better
   representation of the Sponge project when used as an affiliate or reference.
 
-* Create a vastly modified version of Spongie, where they become unrecognizable or clearly different from the
+* Create a vastly modified version of Spongie, where she becomes unrecognizable or clearly different from the
   original Spongie mascot.
 
-* Add your project image to Spongie, or vice versa.
+* Add your project image to Spongie or the logo, nor vice versa.
 
-* Claim Spongie as your own mascot, or use them as a mascot for your own project.
+* Claim Spongie as your mascot, nor use her as a mascot for your own project.
 
-* Sell or use Spongie in commerce without permission.
+* Sell or use Spongie or the logo in commerce without permission.
 
 * Change any colors or dimensions.
 


### PR DESCRIPTION
Once the SpongeAssets repository becomes available to the public, this PR will adjust the Art Assets page to redirect users.

Solves #457
