### PR TITLE
Document implementation-dependent plugins using MCP and plugin mixins

### DIFF
--- a/source/about/faq.rst
+++ b/source/about/faq.rst
@@ -118,6 +118,8 @@ modding and will continue to do so.
 Will I Be Able to Access the Server Internals In My Plugins?
 ------------------------------------------------------------
 
-Accessing the server internals (known as "NMS" or "net.minecraft.server" in CraftBukkit) can be done through Forge,
+Accessing the server internals (known as "NMS" or "net.minecraft.server" in CraftBukkit) can be done through MCP,
 which has a large number of names de-obfuscated. However, be aware that accessing the server internals raises the risk
 of your plugin breaking - this is your prerogative.
+
+See :doc:`../plugin/internals/index` for an introduction about using MCP in your plugin.

--- a/source/plugin/buildsystem.rst
+++ b/source/plugin/buildsystem.rst
@@ -16,6 +16,8 @@ majority of build systems for Java projects. The following sections will focus o
 most common choices as build systems. If you're unsure which one to use we recommend using Gradle_ as it is also used
 for the Sponge projects and provides the best integration for Sponge plugins.
 
+.. _gradle-setup:
+
 Gradle
 ======
 Gradle_ uses Groovy_-based scripts for configuring projects. A Gradle_ project typically consists of a ``build.gradle``

--- a/source/plugin/index.rst
+++ b/source/plugin/index.rst
@@ -62,3 +62,4 @@ Contents
     plugin-meta
     ray-tracing
     tutorials
+    internals/index

--- a/source/plugin/internals/access-transformers.rst
+++ b/source/plugin/internals/access-transformers.rst
@@ -1,0 +1,71 @@
+===================
+Access Transformers
+===================
+
+Since some parts of the Minecraft code were not designed to be used from the outside, you may find yourself in a
+situation in which you need to access a field or method that is not public. While you would normally use reflection to
+access the field or method, MCP will make this more difficult since you have two different names - the MCP names in the
+development environment and the Searge names in production.
+
+For example to access the method ``tick()`` using reflection you would need to use ``tick`` in the development
+environment, but ``func_71217_p`` in production. The re-obfuscation step only handles direct references to methods
+and fields, not the string parameter passed to the reflection call.
+
+As a solution, ForgeGradle supports using access transformers (or AT) that automatically make the specified
+methods/fields public so you can reference them directly (without reflection). While they are primarily intented for
+usage with the Minecraft code base, they can be also applied to classes from other projects. If configured in the JAR
+manifest of the plugin, SpongeVanilla and Forge will also apply them in production.
+
+Setup
+-----
+ForgeGradle will automatically scan for access transformer files with the file name suffix ``_at.cfg`` in your resource
+folders. To be able to use the access transformer at runtime, you need to add them to a ``META-INF`` folder in your
+resource directory, for example ``META-INF/myplugin_at.cfg``.
+
+There are 3 different types of access transformers: you can change the modifiers of classes, fields and methods.
+An access transformer line is defined by 2 parts (for classes) or 3 parts (for fields and methods), each separated by a
+space.
+
+- The access type you want to change the method/field to, e.g. ``public`` or ``protected``. To remove ``final`` from a
+  field, append ``-f`` after the access type, e.g. ``public-f``.
+- Full qualified class name, e.g. ``net.minecraft.server.MinecraftServer``
+- For fields and methods: Searge field name or method name and method signature, e.g. ``field_54654_a`` or ``func_4444_a()V``
+
+.. tip::
+    You can add comments by prefixing them with ``#``. A good convention is to add the MCP name after each access
+    transformer line so you know which field/method the line is referring to.
+
+Here are two examples for access transformer lines:
+
+::
+
+    public-f net.minecraft.server.MinecraftServer field_71308_o # anvilFile
+    public net.minecraft.server.MinecraftServer func_71260_j()V # stopServer
+    public-f net.minecraft.item.ItemStack
+
+To apply the access transformers to your development environment, run the Gradle ``setupDecompWorkspace`` task again and
+refresh your Gradle project:
+
+.. code-block:: bash
+
+    gradle setupDecompWorkspace
+
+.. tip::
+    You can use the `MCP bot <http://mcpbot.bspk.rs/help>`_ which is present in the MCP and Sponge IRC channels to
+    quickly get the access transformer line for a field or method. After looking up a method using ``!gm <mcp method
+    name>`` or a field using ``!gf <mcp field name>``, simply copy the listed ``AT`` line to your access transformer
+    file.
+
+.. note::
+    Making a field/method less accessible (e.g. ``public`` -> ``private``) is not supported.
+
+Production
+``````````
+To apply the access transformers in production, you need to add a ``FMLAT`` manifest entry to your plugin with the file
+name of your access transformer in the ``META-INF`` directory.
+
+.. code-block:: groovy
+
+    jar {
+        manifest.attributes('FMLAT': 'myplugin_at.cfg')
+    }

--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -1,0 +1,69 @@
+=======================
+Internal Sponge Classes
+=======================
+
+You can add SpongeCommon, SpongeVanilla or SpongeForge as a dependency to your plugin project if you need to access
+internal Sponge classes.
+
+.. warning::
+    You should only add a specific implementation dependency when really necessary. If possible, use SpongeAPI or
+    request feature additions on the `SpongeAPI issue tracker <https://github.com/SpongePowered/SpongeAPI/issues>`_.
+
+In addition to the normal artifacts, the implementation modules provide a ``dev`` artifact which can be easily used in
+the IDE, since it is not re-obfuscated. All implementation modules have the API module already included, so you do not
+need an extra dependency on SpongeAPI.
+
+SpongeCommon
+------------
+
+- **Group ID**: ``org.spongepowered``
+- **Artifact ID**: ``spongecommon``
+- **Version**: Same as SpongeAPI
+- **Classifier**: ``dev``
+
+Example Using Gradle
+````````````````````
+
+.. code-block:: groovy
+
+    dependencies {
+        compile 'org.spongepowered:spongecommon:5.0.0-SNAPSHOT:dev'
+    }
+
+SpongeVanilla
+-------------
+
+Choose a build from the downloads page and copy the full version string to your dependency definition.
+
+- **Group ID**: ``org.spongepowered``
+- **Artifact ID**: ``spongevanilla``
+- **Version**: Use a build version from the downloads page
+- **Classifier**: ``dev``
+
+Example Using Gradle
+````````````````````
+
+.. code-block:: groovy
+
+    dependencies {
+        compile 'org.spongepowered:spongevanilla:1.8.9-4.2.0-BETA-348:dev'
+    }
+
+SpongeForge
+-----------
+
+Choose a build from the downloads page and copy the full version string to your dependency definition.
+
+- **Group ID**: ``org.spongepowered``
+- **Artifact ID**: ``spongeforge``
+- **Version**: Use a build version from the downloads page
+- **Classifier**: ``dev``
+
+Example Using Gradle
+````````````````````
+
+.. code-block:: groovy
+
+    dependencies {
+        compile 'org.spongepowered:spongeforge:1.8.9-1890-4.2.0-BETA-1625:dev'
+    }

--- a/source/plugin/internals/index.rst
+++ b/source/plugin/internals/index.rst
@@ -1,0 +1,37 @@
+================================
+Implementation-dependent Plugins
+================================
+
+There are various reasons for bypassing SpongeAPI and accessing the internal Minecraft implementation directly:
+
+- A part of SpongeAPI is not implemented yet. In this case you can temporarily bypass the API in your plugins. However,
+  in most cases the better option is attempting to contribute the missing implementation to Sponge so other plugin
+  developers can profit from the implemented API.
+- You need access to an implementation-dependent feature which is not supported by SpongeAPI (on purpose).
+- You want to optimize or customize the implementation specifically for your server.
+
+.. warning::
+    Depending on special implementation features will make your plugin only work on the implementation you build it
+    against (and likely also only on a specific version). Unless you are certain that accessing the implementation is
+    necessary we highly recommend building plugins only against SpongeAPI.
+
+.. note::
+    The following articles assume you build your plugin for SpongeVanilla/SpongeForge. The plugin will not be usable on
+    any other implementation.
+
+SpongeVanilla and SpongeForge use MCP as development environment for the internal Minecraft code. Continue at :doc:`mcp`
+for a short overview about MCP or continue directly with :doc:`mcp-setup` for an introduction about using MCP in
+plugins.
+
+Contents
+========
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    mcp
+    mcp-setup
+    access-transformers
+    mixins
+    implementation

--- a/source/plugin/internals/mcp-setup.rst
+++ b/source/plugin/internals/mcp-setup.rst
@@ -1,0 +1,116 @@
+====================
+Using MCP in Plugins
+====================
+
+ForgeGradle_ is a Gradle plugin which integrates the MCP workflow into the Gradle build system. It handles setting up
+the workspace, as well as the re-obfuscation of your plugin.
+
+.. note::
+    Since ForgeGradle depends on Gradle, the following pages assume you are using Gradle to build your plugin. See
+    :doc:`../project/gradle` to get started.
+
+Configuring ForgeGradle
+-----------------------
+You can choose between two different types of workspaces:
+
+- **Vanilla workspace:** Supports plugins for SpongeVanilla **and** SpongeForge.
+- **Forge workspace:** Supports **only** plugins for SpongeForge (and **not** SpongeVanilla).
+
+.. note::
+    In most cases, the Vanilla workspace can be used for SpongeVanilla and SpongeForge. In some cases, there may be
+    problems on one of the platforms because of changes in the Minecraft code by Forge. Make sure to always test your
+    plugin on both platforms when using MCP.
+
+Choosing a MCP mappings version
+```````````````````````````````
+To setup a MCP workspace you need to specify the MCP mappings version that will be used to de-obfuscate the Minecraft
+source with human-readable names. A list of MCP mappings versions is available on the
+`Export page of the MCPBot <http://export.mcpbot.bspk.rs>`_.
+
+There are stable versions (released from time to time) and daily snapshots which contain the latest name changes. If you
+do not need a specific name that was added recently, use a stable version (if available for your Minecraft version),
+otherwise use the latest snapshot version.
+
+Click the button for the version you want to use and select "Use in ForgeGradle". Then copy the provided version to your
+Gradle build script (insert it in the ``snapshot_xxx`` placeholder below).
+
+Vanilla Workspace
+`````````````````
+.. code-block:: groovy
+
+    buildscript {
+        repositories {
+            maven {
+                name = 'forge'
+                url = 'http://files.minecraftforge.net/maven'
+            }
+        }
+
+        dependencies {
+            classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        }
+    }
+
+    plugins {
+        id 'org.spongepowered.plugin' version '0.8.1'
+        id 'net.minecrell.vanillagradle.server' version '2.2-3'
+    }
+
+    minecraft {
+        version = '1.10.2'
+        // TODO: Replace with your mappings version, e.g. snapshot_20170120
+        mappings = 'YOUR_MAPPINGS_VERSION'
+    }
+
+Forge Workspace
+```````````````
+.. code-block:: groovy
+
+    buildscript {
+        repositories {
+            maven {
+                name = 'forge'
+                url = 'http://files.minecraftforge.net/maven'
+            }
+        }
+
+        dependencies {
+            classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+        }
+    }
+
+    plugins {
+        id 'org.spongepowered.plugin' version '0.8.1'
+    }
+
+    apply plugin: 'net.minecraftforge.gradle.forge'
+
+    minecraft {
+        forgeVersion = '1944' // TODO: Configure Forge build here
+        // TODO: Replace with your mappings version, e.g. snapshot_20170120
+        mappings = 'YOUR_MAPPINGS_VERSION'
+    }
+
+Setting Up the Workspace
+------------------------
+Every time you update the Minecraft or mappings version, or want to re-import your project, you need to start with setting
+up your workspace using Gradle. To do that, run the ``setupDecompWorkspace`` Gradle task of your project, before
+importing the project into your IDE:
+
+.. code-block:: bash
+
+    gradle setupDecompWorkspace
+
+Now you can import your Gradle project, as described in :doc:`../project/gradle`. If your project is already imported,
+make sure to refresh the Gradle configuration so your IDE can register the new Minecraft dependency.
+
+Building Your Plugin
+--------------------
+ForgeGradle automatically configures your plugin to re-obfuscate to Searge mappings when building it so you can run it
+in production. Make sure to use Gradle's ``build`` task, and not ``jar`` directly.
+
+.. code-block:: bash
+
+    gradle clean build
+
+.. _ForgeGradle: https://github.com/MinecraftForge/ForgeGradle

--- a/source/plugin/internals/mcp.rst
+++ b/source/plugin/internals/mcp.rst
@@ -1,0 +1,75 @@
+====================
+MCP (Mod Coder Pack)
+====================
+
+The `Mod Coder Pack`_ (short MCP) was originally created as a collection of scripts, tools and mappings to make the
+development of mods for Minecraft easier. Since Minecraft is not open-source and for the most part obfuscated,
+development against it was painful since the original code was almost unreadable. MCP was designed as a workspace in
+which developers can create mods using decompiled, deobfuscated (human-readable) Minecraft code.
+
+Workflow
+========
+Using MCP adds additional steps to the development workflow of plugins, simplified below:
+
+- Set up the MCP workspace
+    - Download the Minecraft client/server files
+    - Deobfuscate the code (changing obfuscated names into human-readable ones)
+    - Decompile the code (generating source files from the binary classes)
+- Create a plugin using the deobfuscated Minecraft source
+- Re-obfuscate the plugin code so it can be used with the obfuscated code at runtime
+
+Mappings
+========
+MCP uses two different sets of mappings which are applied separately during the workspace setup. The difference between
+*Notch*, *Searge* and *MCP* mappings can be seen in the example below:
+
+::
+
+    // Notch
+    boolean a(rw ☃);
+
+    // Searge
+    boolean func_72838_d(Entity p_72838_1_);
+
+    // MCP
+    boolean spawnEntityInWorld(Entity entityIn);
+
+- **Notch mappings** are the original names in the obfuscated Minecraft binary. They change regularly with new
+  Minecraft versions.
+- **Searge mappings** contain unique names for all obfuscated methods, fields and parameters, as well as human-readable
+  names for the classes. Unlike Notch mappings they usually stay the same across Minecraft updates unless the method
+  signatures change. For SpongeVanilla and SpongeForge, they are also used in production (outside of your IDE).
+- **MCP mappings** contain human-readable names largely contributed by the community. They are typically only used in
+  the development environment, and then re-obfuscated to Searge or Notch mappings.
+
+.. note::
+    When you create a plugin you work with *MCP mappings* in your development environment. To run the plugin in
+    production (outside of your IDE) you need to re-obfuscate it to *Searge mappings*.
+
+Using the MCPBot
+----------------
+The MCPBot_ is available in the Sponge and MCP IRC channels and allows you to lookup MCP mappings or contribute new
+names. You can send commands to the bot by sending messages in one of the supported channels (e.g. ``#spongedev``).
+
+.. tip::
+    Check out the `MCPBot help page`_ for a list of all available commands.
+
+Contributing new names
+``````````````````````
+You can also contribute names for class members which are still unnamed. Check out the
+`MCPBot help page`_ for more instructions.
+
+.. note::
+    You cannot change existing names. If you would like to suggest changing an existing mapping, create
+    a new issue on the `MCPBot issue tracker on GitHub <https://github.com/ModCoderPack/MCPBot-Issues/issues>`_.
+
+.. seealso::
+
+    `Mod Coder Pack`_
+        Official website of the Mod Coder Pack.
+    `MCPBot help page`_
+        More information about using the MCPBot_.
+
+.. _`Mod Coder Pack`: http://www.modcoderpack.com
+.. _MCPBot: http://mcpbot.bspk.rs/
+.. _`MCPBot help page`: http://mcpbot.bspk.rs/help

--- a/source/plugin/internals/mixins.rst
+++ b/source/plugin/internals/mixins.rst
@@ -1,0 +1,117 @@
+=============
+Plugin Mixins
+=============
+
+`Mixins <https://github.com/SpongePowered/Mixin>`_ can be used to modify classes at runtime before they are loaded. You
+can use them in plugins if you want to optimize a part of the game specifically for your server - without having to fork
+Sponge. The modifications will be bundled directly with your plugin and are only active as long as the plugin is loaded.
+
+.. seealso::
+
+    `Mixin documentation <https://github.com/SpongePowered/Mixin/wiki>`_
+        Mixin documentation including an introduction to Mixins.
+    `Example plugin <https://github.com/SpongePowered/Cookbook/tree/master/Plugin/PluginMixinTest>`_
+        Example plugin which uses Plugin Mixins to print a message when the server is starting.
+
+
+Setup
+-----
+#. Add the Mixin library as dependency to your plugin:
+
+    .. code-block:: groovy
+
+        dependencies {
+            compile 'org.spongepowered:mixin:0.6.6-SNAPSHOT'
+        }
+
+#. Add a new Mixin configuration for your plugin, e.g. ``mixins.myplugin.json`` inside your resource folder:
+
+    .. code-block:: json
+
+        {
+            "package": "com.example.myplugin.mixin",
+            "refmap": "mixins.myplugin.refmap.json",
+            "target": "@env(DEFAULT)",
+            "compatibilityLevel": "JAVA_8",
+            "mixins": [
+                "MixinMinecraftServer"
+            ]
+        }
+
+#. Add a Mixin class to the specified package:
+
+    .. code-block:: java
+
+        package com.example.myplugin.mixin;
+
+        import net.minecraft.server.MinecraftServer;
+        import org.spongepowered.asm.mixin.Mixin;
+
+        @Mixin(MinecraftServer.class)
+        public abstract class MixinMinecraftServer {
+
+        }
+
+Debugging
+`````````
+Normally, the Mixin configuration is registered inside JAR manifest of the plugin. Since the plugin is not packaged in a
+JAR while debugging inside the IDE you need specify the Mixins to apply as command line options:
+
+#. Add a ``--mixin <mixin config file name>`` option for each Mixin configuration file to the program arguments of your
+   run configuration:
+
+    ::
+
+        --mixin mixins.myplugin.json
+
+Production
+``````````
+If your Mixin is working in your development environment you still need to make some changes to make it work in
+production:
+
+#. Apply the `MixinGradle <https://github.com/SpongePowered/MixinGradle>`_ plugin to your build script:
+
+    .. code-block:: groovy
+
+        buildscript {
+            repositories {
+                maven {
+                    name = 'sponge'
+                    url = 'https://repo.spongepowered.org/maven'
+                }
+            }
+            dependencies {
+                classpath 'org.spongepowered:mixingradle:0.4-SNAPSHOT'
+            }
+        }
+
+        apply plugin: 'org.spongepowered.mixin'
+
+#. Set the refmap from your Mixin configuration:
+
+    .. code-block:: groovy
+
+        sourceSets {
+            main {
+                refMap = "mixins.myplugin.refmap.json"
+            }
+        }
+
+#. Add your Mixin configuration to the JAR manifest. The ``FMLCorePluginContainsFMLMod`` manifest entry is necessary if
+   you want to load your Mixin on SpongeForge:
+
+    .. code-block:: groovy
+
+        jar {
+            manifest.attributes(
+                'TweakClass': 'org.spongepowered.asm.launch.MixinTweaker',
+                'MixinConfigs': 'mixins.myplugin.json',
+                'FMLCorePluginContainsFMLMod': 'true',
+            )
+        }
+
+#. Make sure to re-build the plugin using Gradle. The Mixin should then get applied by SpongeVanilla and SpongeForge.
+
+    .. code-block:: bash
+
+        gradle clean build

--- a/source/plugin/project/gradle.rst
+++ b/source/plugin/project/gradle.rst
@@ -2,38 +2,20 @@
 Setting Up Gradle
 =================
 
-Generally, everything necessary to compile a Sponge plugin using Gradle can be done by simply adding the SpongeAPI
-dependency to your project:
-
-.. code-block:: groovy
-
-    repositories {
-        mavenCentral()
-        maven {
-            name = 'sponge'
-            url = 'http://repo.spongepowered.org/maven'
-        }
-    }
-
-    dependencies {
-        compile 'org.spongepowered:spongeapi:5.0.0'
-    }
-
-However, for further Gradle integration with :doc:`/plugin/plugin-meta`, we're providing an additional **Gradle
-plugin** (called SpongeGradle_) for Sponge plugins to use which allows you to minimize the necessary configuration for
-setting up a plugin project using Gradle.
+.. _using-spongegradle:
 
 Using SpongeGradle
 ==================
-
-.. note::
-    We recommend using **the latest Gradle version** together with SpongeGradle_. The Gradle plugin may not work
-    properly with very old Gradle versions.
 
 Using SpongeGradle_ is very simple and allows you to minimize the necessary Gradle configuration for setting up a
 Sponge plugin on Gradle. Additionally, it provides integration for :doc:`/plugin/plugin-meta`, such as automatically
 contributing the group, project name, version and description defined in your build script to the built plugin, so you
 only need to update your plugin version in one file.
+
+.. tip::
+  Most problems are caused by attempting to use an outdated Gradle version. We recommend using the latest Gradle
+  version together with SpongeGradle_. :ref:`The Gradle section of the build systems page <gradle-setup>` explains how
+  to setup Gradle on your computer.
 
 Below is a simple template that should be usable for most plugins. **Make sure to replace the group with the group ID
 you have chosen before.**
@@ -41,7 +23,7 @@ you have chosen before.**
 .. code-block:: groovy
 
     plugins {
-        id 'org.spongepowered.plugin' version '0.6'
+        id 'org.spongepowered.plugin' version '0.8.1'
     }
 
     group = 'com.example' // TODO
@@ -104,6 +86,30 @@ You can also remove a default value entirely:
                 description = null
             }
         }
+    }
+
+Without SpongeGradle
+====================
+
+.. warning::
+  We recommend using :ref:`SpongeGradle <using-spongegradle>` for Gradle plugins since it will provide additional Gradle
+  integration for Sponge plugins.
+
+Generally, everything necessary to compile a Sponge plugin using Gradle can be done by simply adding the SpongeAPI
+dependency to your project:
+
+.. code-block:: groovy
+
+    repositories {
+        mavenCentral()
+        maven {
+            name = 'sponge'
+            url = 'http://repo.spongepowered.org/maven'
+        }
+    }
+
+    dependencies {
+        compile 'org.spongepowered:spongeapi:5.0.0'
     }
 
 .. _SpongeGradle: https://github.com/SpongePowered/SpongeGradle


### PR DESCRIPTION
Adds some docs for plugins which are implementation-dependent by using MCP or plugin mixins which are available in SpongeVanilla. Consists out of 6 pages:
- Index page explains when (and when not to) use MCP
- Introduction page for MCP (just the basics that are quite important for plugin developers to know)
- MCP setup for plugins
- Access transformers
- Plugin mixins
- Dependency definition for Sponge implementations

If you have any very minor fixes (e.g. language fixes, ...) I'd appreciate if you could fix them directly on the branch (if possible) :3
