### PR TITLE
Add warning about server availability

### DIFF
--- a/source/plugin/lifecycle.rst
+++ b/source/plugin/lifecycle.rst
@@ -20,6 +20,10 @@ order. For example, plugin A containing "[required-]after:B" will get each event
 the given state. Additionally, lifecycle states are global. This means that all plugins visible to each other must be
 transitioned through all states at once.
 
+.. warning::
+    The Sponge ``Server`` object is not always available. Availability can be checked using the method
+    ``Sponge.isServerAvailable()`` or ``Game.isServerAvailable()``.
+
 State Events
 ============
 


### PR DESCRIPTION
Adds a warning the the plugin lifecycle page stating the the server object is not always available.

**Note:** This change is only present in API 5, Minecraft 1.9+.