### PR TITLE
Cut 2016 release date

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -27,8 +27,8 @@ or visit their repositories on GitHub:
 
 .. note::
 
-    Sponge is still in development. Beta builds of both SpongeForge and SpongeVanilla are currently
-    available for :doc:`downloads`, but an official release will not be available until later in 2016.
+    Sponge development is ongoing. Beta and Experimental builds of both SpongeForge and SpongeVanilla are currently
+    available for :doc:`downloads`.
 
 Contents
 ========


### PR DESCRIPTION
This should also get cherry picked into earlier Docs versions.
When or if we have a new target date for "release" we can revisit this.