### PR TITLE
irc links: use https or the secure irc port where available

### DIFF
--- a/source/contributing/spongedocs.rst
+++ b/source/contributing/spongedocs.rst
@@ -19,7 +19,7 @@ there are three ways of making us aware of the problem:
 
 #. Create an `Issue on the SpongeDocs GitHub <https://github.com/SpongePowered/SpongeDocs/issues>`_
 #. Create a Posting on the `SpongeDocs Forums Category <https://forums.spongepowered.org/c/sponge-docs>`_
-#. Visit us in the `#spongedocs channel on irc.esper.net <irc://irc.esper.net:6667/spongedocs>`_ (you need to be registered)
+#. Visit us in the `#spongedocs channel on irc.esper.net <ircs://irc.esper.net:6697/#spongedocs>`_ (you need to be registered)
 
 Writing the Docs
 ================
@@ -31,7 +31,7 @@ are some parts you do not understand. There will always be someone able to fill 
 
 The Docs are written in reStructuredText (reST), if you're familiar with Markdown (md) the step to reST shouldn't be to
 hard. If you're having issues with it we suggest that you join our `forums <https://forums.spongepowered.org/>`_ or
-`#SpongeDocs <irc://irc.esper.net:6667/spongedocs>`_ on Esper.net and ask for help there.
+`#SpongeDocs <ircs://irc.esper.net:6697/#spongedocs>`_ on Esper.net and ask for help there.
 
 Style Guide
 ===========

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -20,7 +20,7 @@ This config was generated using SpongeForge build 2022 (with Forge 2202), Sponge
     # # If you need help with the configuration or have any questions related to Sponge,
     # # join us at the IRC or drop by our forums and leave a post.
     # 
-    # # IRC: #sponge @ irc.esper.net ( http://webchat.esper.net/?channel=sponge )
+    # # IRC: #sponge @ irc.esper.net ( https://webchat.esper.net/?channel=sponge )
     # # Forums: https://forums.spongepowered.org/
     # 
 


### PR DESCRIPTION
Replaces usage of port 6667 with port 6697 for TLS connections
and https instead of http for the webchat.

note: I haven't tested this myself; but it should be pretty straightforward.

Here's a wikipedia page on it: https://en.wikipedia.org/wiki/Internet_Relay_Chat#URI_scheme

The mIRC caveat is unfortunately true, but that's a problem with the client considering channel prefixes of `>` and such exist, assuming a prefix is a mistake. Good job, mIRC.