### PR TITLE
Updated Eclipse's Gradle integration steps

### DIFF
--- a/source/plugin/workspace/eclipse.rst
+++ b/source/plugin/workspace/eclipse.rst
@@ -13,13 +13,17 @@ build system such as Maven or Gradle <../buildsystem/>`.
 Gradle
 ======
 
-Creating your project
-~~~~~~~~~~~~~~~~~~~~~
+Preparing Gradle
+~~~~~~~~~~~~~~~~
+
+.. note::
+
+    Gradle is automatically included in Eclipse starting from the Neon release (June 22, 2016) and later. These steps are only required for earlier versions.
 
 You must first install the **Gradle Integration Plugin** before using Gradle in Eclipse. This only needs to be done
 upon the creation of your first project.
 
-.. note::
+.. tip::
 
     Typically, you do not need the optional Spring modules distributed with this plugin, so you can uncheck them during
     installation.
@@ -29,8 +33,10 @@ upon the creation of your first project.
 * Search for ``Gradle Integration Plugin``.
 * Install the **Gradle Integration Plugin**.
 
-You may then proceed to create your project.
+Creating your project
+~~~~~~~~~~~~~~~~~~~~~
 
+* Open **Eclipse**.
 * Click ``File > New > Other``.
 * Select ``Gradle > Gradle Project``.
 * Click ``Next``.

--- a/source/plugin/workspace/eclipse.rst
+++ b/source/plugin/workspace/eclipse.rst
@@ -41,7 +41,7 @@ Editing the build script
 
 * Open ``build.gradle`` in the navigator.
 * Edit the build script according to the instructions at :doc:`../project/gradle`.
-* Right-click your project, and select ``Gradle > Refresh Dependencies``.
+* Right-click your project, and select ``Gradle > Refresh Gradle Project``.
 
 Importing your project
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Updated Gradle integration (now [automatically included](https://projects.eclipse.org/releases/neon) within Eclipse Neon).
- Changed dependency-refresh action to match current Eclipse description.
![Screenshot](https://cloud.githubusercontent.com/assets/19743416/26650206/f507a824-4648-11e7-8351-fa120a811e82.png)
