### PR TITLE
Fix Sponge Discord server link.

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -123,7 +123,7 @@ Links
 
 -  `Sponge Homepage <https://spongepowered.org>`_
 -  `Sponge Forums <https://forums.spongepowered.org>`_
--  `Sponge Discord <https://discord.gg/qXD2weC>`_
+-  `Sponge Discord <https://discord.gg/PtaGRAs>`_
 -  `Sponge Downloads <https://spongepowered.org/downloads>`_
 -  `SpongeAPI Issue Tracker <https://github.com/SpongePowered/SpongeAPI/issues?q=>`_
 -  `SpongeAPI Javadocs <https://jd.spongepowered.org>`_


### PR DESCRIPTION
Already pushed to stable (https://github.com/SpongePowered/SpongeDocs/commit/672db2714ec0238a77e03ba7c9ee03d1f409c026), but I can't push it to 5.1.0 for some reason.