### PR TITLE
Added missing namespace for dimension commands

### DIFF
--- a/source/server/getting-started/configuration/index.rst
+++ b/source/server/getting-started/configuration/index.rst
@@ -64,7 +64,7 @@ Here is an example of this command in action:
 
 .. code-block:: java
 
-    /sponge config -d nether logging.chunk-load true
+    /sponge config -d minecraft:nether logging.chunk-load true
 
 This will set the config to log when chunks are loaded for the nether.
 
@@ -73,7 +73,7 @@ If you need to check the value of a key, you would need to omit the *value*. Che
 
 .. code-block:: java
 
-    /sponge config -d nether logging.chunk-load
+    /sponge config -d minecraft:nether logging.chunk-load
 
 Saving a World Config
 ~~~~~~~~~~~~~~~~~~~~~
@@ -107,4 +107,4 @@ Here is an example of reloading the end world config file:
 
 .. code-block:: java
 
-    /sponge reload -d the_end
+    /sponge reload -d minecraft:the_end

--- a/source/server/spongineer/commands.rst
+++ b/source/server/spongineer/commands.rst
@@ -74,7 +74,7 @@ Command                 Description                               Permission
       Since no dimension was specified, the dimension would default to the sender(player) dimension. So if you were in a
       mystcraft dimension, this would alter the mystcraft dimension config.
 
-    b. ``/sponge config -d nether logging.chunk-load true``
+    b. ``/sponge config -d minecraft:nether logging.chunk-load true``
 
     Since a dimension type was specified, this would alter the nether dimension config (and hence all nether worlds).
 


### PR DESCRIPTION
No idea when this was changed, but these commands don't work without namespace anymore. Tested with 1.10 and 1.11

![image](https://user-images.githubusercontent.com/2097483/32695251-6e5f8c94-c756-11e7-8216-e509a1857492.png)
