### PR TITLE
Document login permissions. Fixes #641

### DIFF
--- a/source/plugin/permissions.rst
+++ b/source/plugin/permissions.rst
@@ -13,6 +13,11 @@ Permissions
     org.spongepowered.api.service.permission.SubjectCollection
     org.spongepowered.api.service.permission.SubjectData
 
+
+If you are interested in the permissions that are used in vanilla commands have a look at 
+:doc:`this page <../../server/spongineer/commands>`. For customizing the permission levels refer to the
+:doc:`server permissions <../../server/management/permissions>` page or your permission plugin's documentation.
+
 Permission
 ==========
 

--- a/source/server/management/permissions.rst
+++ b/source/server/management/permissions.rst
@@ -2,9 +2,8 @@
 Managing Permissions
 ====================
 
-You can configure who has access to what if you are running a server by making use of permissions.
-Specific permissions for Sponge, Forge and Minecraft commands are shown on the :doc:`../../server/spongineer/commands`
-page.
+You can configure who has access to what if you are running a server by making use of :doc:`../../plugin/permissions`.
+Specific permissions for Sponge, Forge and Minecraft commands are shown on the :doc:`../spongineer/commands` page.
 
 
 Operator Level

--- a/source/server/management/whitelist.rst
+++ b/source/server/management/whitelist.rst
@@ -7,10 +7,11 @@ server, regardless of whether they're in the whitelist.
 
 
 When the whitelist function is enabled, only players named on the whitelist will be allowed to login to your server.
-Players can be added to the whitelist through the usage of in-game commands or by editing the ``whitelist.json`` file.
-Beware, however: if you manually change the file, you will have to reload the whitelist or restart the server for the
-changes to go into effect. Additionally, pay special heed to the syntax, as the whitelist won't work if it is wrong. An
-example of a correctly formatted whitelist file can be found at :doc:`../../server/getting-started/configuration/json`.
+Players can be added to the whitelist through the usage of in-game :doc:`../spongineer/commands` or by editing the
+``whitelist.json`` file. Beware, however: if you manually change the file, you will have to reload the whitelist or
+restart the server for the changes to go into effect. Additionally, pay special heed to the syntax, as the whitelist
+won't work if it is wrong. An example of a correctly formatted whitelist file can be found at
+:doc:`../../server/getting-started/configuration/json`.
 
 - To enable the whitelist, use ``/whitelist on``
 - To disable the whitelist, use ``/whitelist off``
@@ -22,3 +23,15 @@ example of a correctly formatted whitelist file can be found at :doc:`../../serv
 The whitelist can also be enabled or disabled by editing the
 :doc:`../../server/getting-started/configuration/server-properties` file, although this will only affect the game after
 server reload or restart.
+
+Permissions
+===========
+
+You can also use these :doc:`../../plugin/permissions` to manage the access to your server.
+
+=================================== ====================================================
+Permission                          Description
+=================================== ====================================================
+minecraft.login.bypass-whitelist    Treat the user as whitelisted.
+minecraft.login.bypass-player-limit Allow this user to bypass the server's player limit.
+=================================== ====================================================

--- a/source/server/management/whitelist.rst
+++ b/source/server/management/whitelist.rst
@@ -29,9 +29,10 @@ Permissions
 
 You can also use these :doc:`../../plugin/permissions` to manage the access to your server.
 
-=================================== ====================================================
+=================================== ====================================================================
 Permission                          Description
-=================================== ====================================================
-minecraft.login.bypass-whitelist    Treat the user as whitelisted.
-minecraft.login.bypass-player-limit Allow this user to bypass the server's player limit.
-=================================== ====================================================
+=================================== ====================================================================
+minecraft.login.bypass-whitelist    Treat the user as whitelisted. Defaults to ``Op``-only.
+minecraft.login.bypass-player-limit Allow this user to bypass the server's player limit. Defaults to the
+                                    ``bypassesPlayerLimit`` option in ``ops.json``.
+=================================== ====================================================================

--- a/source/server/spongineer/commands.rst
+++ b/source/server/spongineer/commands.rst
@@ -5,10 +5,10 @@ Commands
 Commands are one method in which server operators can administer their server, and in which players can interact with
 the server.
 
-In Sponge, commands follow a system of permissions. Permissions allow server operators to control who can access what
-commands. By default, all commands are granted to players with OP status. Players without operator status do not have
-access to administrative commands or commands that require an assigned permission node. A server operator can fine-tune
-who can access what commands by adding/negating permission nodes through a permissions plugin.
+In Sponge, commands follow a system of :doc:`../../plugin/permissions`. Permissions allow server operators to control
+who can access what commands. By default, all commands are granted to players with OP status. Players without operator
+status do not have access to administrative commands or commands that require an assigned permission node. A server
+operator can fine-tune who can access what commands by adding/negating permission nodes through a permissions plugin.
 
 .. note::
 
@@ -178,6 +178,11 @@ which is normally ``@`` by default.
 * Allow player to bypass spawn-protection on all worlds: ``minecraft.spawn-protection.override``
 * Allow editing an ordinary commandblock of the given name: ``minecraft.commandblock.edit.block.<name>``
 * Allow editing a minecart commandblock of the given name: ``minecraft.commandblock.edit.minecart.<name>``
+
+There are also extra permissions managing the access to the server:
+
+* Treat the user as whitelisted: ``minecraft.login.bypass-whitelist``
+* Allow this user to bypass the server's player limit: ``minecraft.login.bypass-player-limit``
 
 
 Player Commands


### PR DESCRIPTION
* Document the permission strings (#641)
* Add more cross references between server commands/permission pages and the plugin permissions page

@Cybermaxke