### PR TITLE
Add docs on the new child command option in CommandSpec.Builder

### DIFF
--- a/source/plugin/commands/childcommands.rst
+++ b/source/plugin/commands/childcommands.rst
@@ -7,6 +7,7 @@ Child Commands
     org.spongepowered.api.command.spec.CommandExecutor
     org.spongepowered.api.command.spec.CommandSpec
     org.spongepowered.api.command.spec.CommandSpec.Builder
+    org.spongepowered.api.command.args.ArgumentParseException
     java.lang.String
 
 The :javadoc:`CommandSpec` builder supports hierarchical command structures like this:
@@ -55,7 +56,28 @@ The first alias supplied is the primary one and will appear in the usage message
 
     Sponge.getCommandManager().register(plugin, mailCommandSpec, "mail", "email");
 
-.. note::
+## Fallback behavior
 
-    If a :javadoc:`CommandExecutor` was set for the parent command, it is used as a fallback if the arguments do not
-    match one of the child command aliases. Setting an executor is not required.
+If a command has child commands, a :javadoc:`CommandExecutor`, set through
+:javadoc:`CommandSpec.Builder#executor(CommandExecutor)` and their associated
+:javadoc:`CommandSpec.Builder#arguments(CommandElement)` are optional. The behavior of error in selection and
+argument parsing of child commands is dependent on whether this parent executor exists.
+
+If a parent executor has not been set, then if the requested child command could not be found or the arguments
+cannot be parsed, then an :javadoc:`ArgumentParseException` will be thrown.
+
+If a parent executor has been set for the parent command, it is used as a fallback if the first argument does
+not match one of the child command aliases. If a child command is selected but the arguments do not parse, one of
+the following will happen based on what :javadoc:`CommandSpec.Builder#childArgumentParseExceptionFallback(boolean)`
+is set to:
+
+* If `true` (the default), the :javadoc:`ArgumentParseException` is discarded and the arguments from the parent
+  commands are parsed. If they fail, the exception for the parent command will be displayed. This is the same
+  behavior as previous API revisions, where child command argument parsing exceptions will not be displayed.
+* If `false`, the parent executor is not executed and the :javadoc:`ArgumentParseException` is thrown, returning
+  the exception from the child command argument that failed to parse, but may prevent some combination of parent
+  commands and arguments from being executed (if the first argument of the fallback could be the same as the
+  child command).
+
+In all cases, if the arguments parse succesfully but the child executor throws an exception, the fallback
+executor (if any) is not executed and the error message from the child executor is displayed.


### PR DESCRIPTION
This is for API 7, don't merge this for API 6 docs before it gets split off!

In API 7, a new option for child commands was added to allow developers choose what would happen if a child command couldn't parse its arguments AND there was a fallback/parent executor - `CommandSpec.Builder#childArgumentParseExceptionFallback`. I've added information on how child command parsing works in API 7 - review on the clarity, headings, wording and the en_US spelling is appreciated.