### PR TITLE
Update some versions so people don't mistakenly use outdated stuff

### DIFF
--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -27,7 +27,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongecommon:5.0.0-SNAPSHOT:dev'
+        compile 'org.spongepowered:spongecommon:7.1.0-SNAPSHOT:dev'
     }
 
 SpongeVanilla
@@ -46,7 +46,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongevanilla:1.8.9-4.2.0-BETA-348:dev'
+        compile 'org.spongepowered:spongevanilla:1.12.2-7.1.0-BETA-5:dev'
     }
 
 SpongeForge
@@ -65,5 +65,5 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongeforge:1.8.9-1890-4.2.0-BETA-1625:dev'
+        compile 'org.spongepowered:spongeforge:1.12.2-2555-7.1.0-BETA-2825:dev'
     }

--- a/source/plugin/internals/mcp-setup.rst
+++ b/source/plugin/internals/mcp-setup.rst
@@ -47,18 +47,18 @@ Vanilla Workspace
         }
 
         dependencies {
-            classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+            classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
         }
     }
 
     plugins {
         id 'org.spongepowered.plugin' version '0.8.1'
-        id 'net.minecrell.vanillagradle.server' version '2.2-3'
+        id 'net.minecrell.vanillagradle.server' version '2.2-6'
     }
 
     minecraft {
-        version = '1.10.2'
-        // TODO: Replace with your mappings version, e.g. snapshot_20170120
+        version = '1.12.2'
+        // TODO: Replace with your mappings version, e.g. snapshot_20180106
         mappings = 'YOUR_MAPPINGS_VERSION'
     }
 
@@ -75,7 +75,7 @@ Forge Workspace
         }
 
         dependencies {
-            classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
+            classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
         }
     }
 
@@ -86,8 +86,8 @@ Forge Workspace
     apply plugin: 'net.minecraftforge.gradle.forge'
 
     minecraft {
-        forgeVersion = '1944' // TODO: Configure Forge build here
-        // TODO: Replace with your mappings version, e.g. snapshot_20170120
+        forgeVersion = '2584' // TODO: Configure Forge build here
+        // TODO: Replace with your mappings version, e.g. snapshot_20180106
         mappings = 'YOUR_MAPPINGS_VERSION'
     }
 

--- a/source/plugin/internals/mixins.rst
+++ b/source/plugin/internals/mixins.rst
@@ -21,7 +21,7 @@ Setup
     .. code-block:: groovy
 
         dependencies {
-            compile 'org.spongepowered:mixin:0.6.6-SNAPSHOT'
+            compile 'org.spongepowered:mixin:0.7.5-SNAPSHOT'
         }
 
 #. Add a new Mixin configuration for your plugin, e.g. ``mixins.myplugin.json`` inside your resource folder:
@@ -81,7 +81,7 @@ production:
                 }
             }
             dependencies {
-                classpath 'org.spongepowered:mixingradle:0.4-SNAPSHOT'
+                classpath 'org.spongepowered:mixingradle:0.6-SNAPSHOT'
             }
         }
 


### PR DESCRIPTION
While some of these mention that the developer should configure the version themselves, many will just pull the versions straight from here which were quite outdated, so I updated these implementation specific versions to their latest releases, and for Forge its most recent recommended release.