### PR TITLE
Fixes broken references to javadoc

### DIFF
--- a/source/plugin/blocks/modifying.rst
+++ b/source/plugin/blocks/modifying.rst
@@ -11,13 +11,12 @@ Modifying Blocks
     org.spongepowered.api.data.manipulator.mutable.WetData
     org.spongepowered.api.data.manipulator.mutable.block.DirtData
     org.spongepowered.api.data.type.DirtTypes
-    org.spongepowered.api.event.cause.Cause
     org.spongepowered.api.world.Location
 
 Changing a Blocks Type
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Changing the Type of a Block is as simple as calling the :javadoc:`Location#setBlockType(BlockType, Cause)` method with
+Changing the Type of a Block is as simple as calling the :javadoc:`Location#setBlockType(BlockType)` method with
 the new :javadoc:`BlockType`. As with most block modifications, we need to supply a cause for the block change. In most
 cases, this can be your main plugin class. The following code turns the block at the given :javadoc:`Location` into a
 sponge:
@@ -34,12 +33,12 @@ sponge:
     }
 
 It's as simple as that. If you just want to 'delete' a block (which is done by replacing it with air), you may just
-use the :javadoc:`Location#removeBlock(Cause)` method provided by ``Location``.
+use the :javadoc:`Location#removeBlock()` method provided by ``Location``.
 
 Altering Block States
 ~~~~~~~~~~~~~~~~~~~~~
 
-Similar to the above example, the ``Location`` class provides a :javadoc:`Location#setBlock(BlockState, Cause)` method
+Similar to the above example, the ``Location`` class provides a :javadoc:`Location#setBlock(BlockState)` method
 accepting a new :javadoc:`BlockState`. To make use of it, you first must acquire a ``BlockState`` you can modify. You
 can do so either by getting the block's current state via the :javadoc:`Location#getBlock()` method or by using a
 ``BlockType``\ 's default state. The latter is demonstrated below. The default state for a Sponge block is retrieved

--- a/source/plugin/commands/childcommands.rst
+++ b/source/plugin/commands/childcommands.rst
@@ -4,6 +4,7 @@ Child Commands
 
 .. javadoc-import::
     org.spongepowered.api.command.CommandCallable
+    org.spongepowered.api.command.args.CommandElement
     org.spongepowered.api.command.spec.CommandExecutor
     org.spongepowered.api.command.spec.CommandSpec
     org.spongepowered.api.command.spec.CommandSpec.Builder

--- a/source/plugin/data/custom/datamanipulators.rst
+++ b/source/plugin/data/custom/datamanipulators.rst
@@ -17,14 +17,14 @@ Custom DataManipulators
     org.spongepowered.api.data.manipulator.mutable.common.AbstractSingleData
     org.spongepowered.api.data.manipulator.mutable.tileentity.FurnaceData
     org.spongepowered.api.data.value.ValueFactory
-    org.spongepowered.api.data.value.mutable.BoundedValue
     org.spongepowered.api.data.value.mutable.MapValue
+    org.spongepowered.api.data.value.mutable.MutableBoundedValue
     org.spongepowered.api.data.value.mutable.Value
-    org.spongepowered.api.data.value.ValueContainer
     org.spongepowered.api.event.game.state.GameInitializationEvent
     org.spongepowered.api.item.inventory.ItemStack
     org.spongepowered.api.util.TypeTokens
     java.lang.Comparable
+    java.lang.String
     java.util.Comparator
     com.google.common.reflect.TypeToken
 
@@ -36,7 +36,7 @@ create a separate API for your custom data. Generally speaking it's best to sepa
 You'll want to define an API method for each "unit" your data, such as a ``String``, ``int``, :javadoc:`ItemStack` or 
 a custom type like ``Home``. These units will be wrapped in a :javadoc:`Value`, which will allow it to be accessed
 with :javadoc:`Key`\s. There are various extensions of ``Value`` depending on which object will be represented, such
-as :javadoc:`MapValue` which provides the standard map operations, or :javadoc:`BoundedValue` which can set
+as :javadoc:`MapValue` which provides the standard map operations, or :javadoc:`MutableBoundedValue` which can set
 limits on the upper and lower bound of the value (like integers). The bounds of the values are verified using a
 :javadoc:`Comparator`.
 
@@ -199,13 +199,13 @@ To register a ``DataManipulator`` Sponge has the :javadoc:`DataRegistration#buil
 Single Types
 ============
 
-Single types require little implementation because much of the work has already been done in the ``AbstractSingleData``
-type you extend from. 
+Single types require little implementation because much of the work has already been done in the
+:javadoc:`AbstractSingleData` type you extend from. 
 
 The "simple" abstract types are the easiest to implement, but are restricted to only the types below:
 
 - ``Boolean``
-- ``Comparable``
+- :javadoc:`Comparable`
 - ``Integer``
 - ``List``
 - ``Map``

--- a/source/plugin/data/custom/index.rst
+++ b/source/plugin/data/custom/index.rst
@@ -2,12 +2,6 @@
 Custom Data
 ===========
 
-.. javadoc-import::
-    org.spongepowered.api.data.DataHolder
-    org.spongepowered.api.data.manipulator.mutable.DataManipulator
-    org.spongepowered.api.data.serialization.DataSerializable
-    org.spongepowered.api.data.value.mutable.Value
-
 Sponge has a powerful :doc:`data <../index>` system, that can do much more than just vanilla features. It's also 
 possible to create your own data objects, allowing you to :doc:`serialize <../serialization>` objects directly to 
 players, entities and more!

--- a/source/plugin/data/custom/serialization.rst
+++ b/source/plugin/data/custom/serialization.rst
@@ -6,12 +6,10 @@ Serializing Custom Data
     org.spongepowered.api.data.DataHolder
     org.spongepowered.api.data.DataQuery
     org.spongepowered.api.data.DataSerializable
-    org.spongepowered.api.data.manipulator.DataManipulator
     org.spongepowered.api.data.manipulator.DataManipulatorBuilder
     org.spongepowered.api.data.persistence.AbstractDataBuilder
     org.spongepowered.api.data.persistence.DataBuilder
     org.spongepowered.api.data.persistence.DataContentUpdater
-    org.spongepowered.api.data.persistence.DataManipulator
     org.spongepowered.api.data.persistence.DataTranslator
     org.spongepowered.api.data.persistence.DataTranslators
 

--- a/source/plugin/database.rst
+++ b/source/plugin/database.rst
@@ -3,6 +3,7 @@ Databases
 =========
 
 .. javadoc-import::
+    java.lang.String
     org.spongepowered.api.service.sql.SqlService
 
 SQL

--- a/source/plugin/event/causes.rst
+++ b/source/plugin/event/causes.rst
@@ -7,7 +7,6 @@ Event Causes
     org.spongepowered.api.event.CauseStackManager
     org.spongepowered.api.event.Event
     org.spongepowered.api.event.block.ChangeBlockEvent
-    org.spongepowered.api.event.block.ChangeBlockEvent.Break
     org.spongepowered.api.event.block.ChangeBlockEvent.Grow
     org.spongepowered.api.event.cause.Cause
     org.spongepowered.api.event.cause.Cause.Builder
@@ -20,7 +19,6 @@ Event Causes
     org.spongepowered.api.profile.GameProfile
     java.lang.Class
     java.lang.Object
-    java.lang.String
     java.util.Stack
 
 Events are great for attaching additional logic to game actions, but they have the drawback of providing next to no

--- a/source/plugin/event/causes.rst
+++ b/source/plugin/event/causes.rst
@@ -179,7 +179,7 @@ simulating in the context (as the simulated player is not directly responsible f
 
 In this example, the variables would be populated, the cause would contain the ``playerToSimulate`` as
 the root cause, the ``sourceRunningSudo`` as the second object in the cause and the :javadoc:`GameProfile`
-as the :javadoc:`EventContextKeys#SIMULATED_PLAYER` context, in addition to anything already in the
+as the :javadoc:`EventContextKeys#PLAYER_SIMULATED` context, in addition to anything already in the
 ``CauseStackManager``. Your event code would be at the bottom of the method.
 
 .. code-block:: java
@@ -191,7 +191,7 @@ as the :javadoc:`EventContextKeys#SIMULATED_PLAYER` context, in addition to anyt
       frame.pushCause(sourceRunningSudo);
       frame.pushCause(playerToSimulate);
 
-      frame.addContext(EventContextKeys.SIMULATED_PLAYER, playerToSimulate.getProfile());
+      frame.addContext(EventContextKeys.PLAYER_SIMULATED, playerToSimulate.getProfile());
 
       Cause cause = frame.getCurrentCause();
     }

--- a/source/plugin/event/custom.rst
+++ b/source/plugin/event/custom.rst
@@ -19,7 +19,7 @@ your event.
 Example: Custom Event Class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following class describes an event indicating a ``Player`` has come in contact with FLARD and is now about to
+The following class describes an event indicating a :javadoc:`Player` has come in contact with FLARD and is now about to
 mutate in a way specified by the event. Since the event targets a player and can be cancelled by listeners, it
 implements both the ``TargetPlayerEvent`` and ``Cancellable`` interfaces.
 

--- a/source/plugin/text/index.rst
+++ b/source/plugin/text/index.rst
@@ -7,8 +7,8 @@ Text
 	org.spongepowered.api.text.Text.Builder
 	org.spongepowered.api.text.action.TextAction
 
-Formatted Text can be created using the :javadoc:`Text.Builder`, as described in this section. The robust Text API can
-be used in a variety of ways to combine styling, coloring, and :javadoc:`TextAction`\s.
+Formatted :javadoc:`Text` can be created using the :javadoc:`Text.Builder`, as described in this section. The robust
+Text API can be used in a variety of ways to combine styling, coloring, and :javadoc:`TextAction`\s.
 
 Pagination, the process of splitting content (such as lists of Text) into discrete pages, will also be discussed in
 this section.


### PR DESCRIPTION
Addresses the bottom two sections (Outdated references of https://github.com/SpongePowered/SpongeDocs/issues/640#issuecomment-366533138)

This does not fix any outdated method references or imports that are no longer present in API 7.

Ready for review.