### PR TITLE
Update GAME_STOPPING and GAME_STOPPED

### DIFF
--- a/source/plugin/lifecycle.rst
+++ b/source/plugin/lifecycle.rst
@@ -13,6 +13,8 @@ Plugin Lifecycle
     org.spongepowered.api.event.game.state.GameStartedServerEvent
     org.spongepowered.api.event.game.state.GameStoppingServerEvent
     org.spongepowered.api.event.game.state.GameStoppedServerEvent
+    org.spongepowered.api.event.game.state.GameStoppingEvent
+    org.spongepowered.api.event.game.state.GameStoppedEvent
 
 Prior to any states that make the plugin visible, the plugin loader first sorts through the available plugins, determines
 if all dependencies are present, and sorts plugins by dependency order. Lifecycle events are given to plugins in this

--- a/source/plugin/lifecycle.rst
+++ b/source/plugin/lifecycle.rst
@@ -110,12 +110,12 @@ the ``/stop`` command is typed. On Clients: The "Close" button or the "Quit Game
 
 **GAME_STOPPING**
 
-The :javadoc:`GameStoppingServerEvent` is triggered.
+The :javadoc:`GameStoppingEvent` is triggered.
 This state occurs immediately before ``GAME_STOPPED``. Plugins providing an API should still be capable of accepting
 basic requests.
 
 **GAME_STOPPED**
 
-The :javadoc:`GameStoppedServerEvent` is triggered.
+The :javadoc:`GameStoppedEvent` is triggered.
 Once this event has finished executing, Minecraft will shut down. No further interaction with the game or other plugins
 should be attempted at this point.


### PR DESCRIPTION
GAME_STOPPING and GAME_STOPPED apparently called the same events as SERVER_STOPPING and SERVER_STOPPED, respectively. I made an educated guess that the server states should call the server events and the game states should call the game events.