### PR TITLE
Text Serializers Formats

### DIFF
--- a/source/plugin/text/representations/configurate.rst
+++ b/source/plugin/text/representations/configurate.rst
@@ -14,7 +14,7 @@ SpongeAPI offers support to serialize text directly to a Configurate configurati
 
 .. tip::
 
-    For information on how to use Configurate to create configuration files for your plugin, please refer to 
+    For information on how to use Configurate to create configuration files for your plugin, please refer to
     :doc:`/plugin/configuration/index`.
 
 For example, the text "Hello World!", formatted with the color red and an underline, would have the following HOCON

--- a/source/plugin/text/representations/configurate.rst
+++ b/source/plugin/text/representations/configurate.rst
@@ -8,15 +8,16 @@ Configuration Format
     ninja.leaping.configurate.loader.ConfigurationLoader
 
 SpongeAPI offers support to serialize text directly to a Configurate configuration file through the use of the
-``TypeToken`` class. :javadoc:`Text` objects are saved using the same node structure as the ``Text``\'s JSON
-representation.
+``TypeToken`` class. :javadoc:`Text` objects are saved using the same node structure as the ``Text``\'s 
+:doc:`json`, but in a more flexible format called :doc:`Human-Optimized Config Object Notation (HOCON) 
+</server/getting-started/configuration/hocon>`.
 
 .. tip::
 
-    For information on how to use Configurate to create configuration files for your plugin, please refer to
+    For information on how to use Configurate to create configuration files for your plugin, please refer to 
     :doc:`/plugin/configuration/index`.
 
-For example, the text "Hello World!", formatted with the color red and an underline would have the following HOCON
+For example, the text "Hello World!", formatted with the color red and an underline, would have the following HOCON
 representation:
 
 .. code-block:: guess
@@ -24,7 +25,7 @@ representation:
     {
         underlined=true
         color=red
-        text="Hello, world!"
+        text="Hello World!"
     }
 
 To save a ``Text`` object simply set the value of your desired node using the following code:

--- a/source/plugin/text/representations/json.rst
+++ b/source/plugin/text/representations/json.rst
@@ -3,12 +3,18 @@ JSON Format
 ===========
 
 JSON is `JavaScript Object Notation <https://www.json.org/>`_, a "light-weight data-interchange format" that is "easy
-for humans to read and write" and "for machines to parse and generate". The
-`Minecraft Wiki <https://minecraft.gamepedia.com/Commands#Raw_JSON_Text>`_ details the structure of text represented
-in JSON.
+for humans to read and write" and "for machines to parse and generate". The JSON web site details the structure of 
+text represented in the JSON format. In addition, the 
+`Minecraft Wiki <https://minecraft.gamepedia.com/Commands#Raw_JSON_Text>`_ provides Minecraft-related information about 
+JSON files.
 
-For example, the text "Hello World!", formatted with the color red and an underline would have the following representation
-in JSON:
+.. tip::
+
+    The data are stored in structures called trees. Each data point on a tree is a node. See 
+    :doc:`/plugin/configuration/nodes` for more information on this topic.
+
+For example, the text "Hello World!", formatted with the color red and an underline, would have the following 
+representation in JSON:
 
 .. code-block:: json
 


### PR DESCRIPTION
This PR started as a correction to an example on the [Configuration Format](https://docs.spongepowered.org/stable/en/plugin/text/representations/configurate.html) page. 

The code block is currently
```
  {
        underlined=true
        color=red
        text="Hello, world!"
    }
```

but should be 
```
  {
        underlined=true
        color=red
        text="Hello World!"
    }
```

I wanted to be sure I wasn't missing something, so I asked for opinions on Discord. My thoughts were confirmed, but it was pointed out that the page is a bit confusing. It starts out talking about JSON representation, yet the page is really about HOCON representation.

After reviewing it and the prior page, [JSON Format](https://docs.spongepowered.org/stable/en/plugin/text/representations/json.html), I realized the confusion came about when the reader goes straight to the Configuration Format page.

To begin with, the JSON Format page relies on two links to provide the foundation of JSON. The links are certainly valid and provide good information; however, they do not prepare the reader for the information given on the Configuration Format page. In particular, the page states in the 2nd sentence,

`Text objects are saved using the same node structure as the Text’s JSON representation.`

Yet, nodes are not mentioned on the JSON Format page or in the links. The result is the reader not thinking in terms of nodes when he or she reads the 2nd sentence.

Furthermore, the Configuration Format page has little, if any, transition or introduction.  The page starts with Configurate and JSON, then delves right into HOCON for the balance of the information while referencing nodes for the first time. The reader is probably still thinking in terms of JSON when working with HOCON is suddenly explained.

So, this PR is a correction to the example, an _attempt_ to clarify and transition the two pages while not creating bloat, and experience for me with the whole process. 😉 