### PR TITLE
Update example of PermissionDescription: fix #710

### DIFF
--- a/source/plugin/permissions.rst
+++ b/source/plugin/permissions.rst
@@ -102,16 +102,13 @@ Usage-Example
     import org.spongepowered.api.service.permission.PermissionDescription.Builder;
     import org.spongepowered.api.service.permission.PermissionService;
     import org.spongepowered.api.text.Text;
-    import java.util.Optional;
 
-    Optional<Builder> optBuilder = permissionService.newDescriptionBuilder(myplugin);
-    if (optBuilder.isPresent()) {
-        Builder builder = optBuilder.get();
-        builder.id("myplugin.commands.teleport.execute")
-               .description(Text.of("Allows the user to execute the teleport command."))
-               .assign(PermissionDescription.ROLE_STAFF, true)
-               .register();
-    }
+    Builder builder = permissionService.newDescriptionBuilder(myplugin);
+    
+    builder.id("myplugin.commands.teleport.execute")
+           .description(Text.of("Allows the user to execute the teleport command."))
+           .assign(PermissionDescription.ROLE_STAFF, true)
+           .register();
 
 Simple-Result
 ~~~~~~~~~~~~~

--- a/source/plugin/permissions.rst
+++ b/source/plugin/permissions.rst
@@ -96,7 +96,7 @@ If you have a dynamic element such as a ``World`` or ``ItemType`` then you can u
 Usage-Example
 ~~~~~~~~~~~~~
 
-.. code-block:: text
+.. code-block:: java
 
     import org.spongepowered.api.service.permission.PermissionDescription;
     import org.spongepowered.api.service.permission.PermissionDescription.Builder;


### PR DESCRIPTION
This fixes the issue #710 by updating the usage-example of PermissionDescription so it doesn't use the Optional anymore which has been removed since 7.0.0.