### PR TITLE
Info about getting a log message to appear in a newly created plugin

### DIFF
--- a/source/plugin/plugin-class.rst
+++ b/source/plugin/plugin-class.rst
@@ -87,15 +87,11 @@ of the :javadoc:`Listener` annotation before the method.
         @Listener
         public void onServerStart(GameStartedServerEvent event)
         {
-            // This message will show up in the server logs
-            logger.debug("MY NEW PLUGIN IS RUNNING!!!");
+            // This message will show up in the server output
+            logger.info("MY NEW PLUGIN IS RUNNING!!!");
         }
 
     }
-
-.. tip::
-
-    If running the Sponge server from the command line with your mod's jar in the mods directory, you may not see the log output in the console.  You should be able to find the log output in the ``logs/latest.log`` file, which contains more detailed server output.   If you run SpongeVanilla or SpongeForge through an IDE (as described in :doc:`debugging`) you may see the plugin's log prints in the IDE output window.
 
 .. tip::
 

--- a/source/plugin/plugin-class.rst
+++ b/source/plugin/plugin-class.rst
@@ -64,7 +64,8 @@ Your plugin can listen for particular events, called **state events**, to be not
 game. In the example below, ``onServerStart()`` is called when the :javadoc:`GameStartedServerEvent` occurs; take note
 of the :javadoc:`Listener` annotation before the method.  
 
-The example below will log a message upon starting the server.  If your plugin is correctly loaded, you should see this message as part of the server's initialization output. 
+The example below will log a message upon starting the server.  If your plugin is correctly loaded,
+you should see this message as part of the server's initialization output.
 
 .. code-block:: java
 
@@ -83,8 +84,7 @@ The example below will log a message upon starting the server.  If your plugin i
         private Logger logger;
 
         @Listener
-        public void onServerStart(GameStartedServerEvent event)
-        {
+        public void onServerStart(GameStartedServerEvent event) {
             logger.info("Successfully running ExamplePlugin!!!");
         }
 
@@ -92,9 +92,9 @@ The example below will log a message upon starting the server.  If your plugin i
 
 .. tip::
 
-    The Sponge documentation provides a guide with more information on events (see :doc:`event/index`). Normally, in addition
-    to prefixing event-handler methods with ``@Listener``, you must also register your object with Sponge's event bus.
-    However, your main plugin class is registered automatically.
+    The Sponge documentation provides a guide with more information on events (see :doc:`event/index`). Normally, in
+    addition to prefixing event-handler methods with ``@Listener``, you must also register your object with Sponge's
+    event bus. However, your main plugin class is registered automatically.
 
 State Events
 ~~~~~~~~~~~~

--- a/source/plugin/plugin-class.rst
+++ b/source/plugin/plugin-class.rst
@@ -66,18 +66,36 @@ of the :javadoc:`Listener` annotation before the method.
 
 .. code-block:: java
 
+    import org.spongepowered.api.plugin.Plugin;
     import org.spongepowered.api.event.Listener;
     import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 
+    // Imports for logger
+    import com.google.inject.Inject;
+    import org.slf4j.Logger;
+
+
     @Plugin(id = "exampleplugin", name = "Example Plugin", version = "1.0", description = "Example")
     public class ExamplePlugin {
+
+        // Logger is automatically assigned to this variable through dependency injection.
+        //  (see the "Logging and Debugging" section in the Sponge documentation for more 
+        //   explanation on logging)
+        @Inject
+        private Logger logger;
+
         @Listener
-        public void onServerStart(GameStartedServerEvent event) {
-            // Hey! The server has started!
-            // Try instantiating your logger in here.
-            // (There's a guide for that)
+        public void onServerStart(GameStartedServerEvent event)
+        {
+            // This message will show up in the server logs
+            logger.debug("MY NEW PLUGIN IS RUNNING!!!");
         }
+
     }
+
+.. tip::
+
+    If running the Sponge server from the command line with your mod's jar in the mods directory, you may not see the log output in the console.  You should be able to find the log output in the ``logs/latest.log`` file, which contains more detailed server output.   If you run SpongeVanilla or SpongeForge through an IDE (as described in :doc:`debugging`) you may see the plugin's log prints in the IDE output window.
 
 .. tip::
 

--- a/source/plugin/plugin-class.rst
+++ b/source/plugin/plugin-class.rst
@@ -62,7 +62,9 @@ interacting with the game, such as registering commands or events.
 
 Your plugin can listen for particular events, called **state events**, to be notified about changes in the state of the
 game. In the example below, ``onServerStart()`` is called when the :javadoc:`GameStartedServerEvent` occurs; take note
-of the :javadoc:`Listener` annotation before the method.
+of the :javadoc:`Listener` annotation before the method.  
+
+The example below will log a message upon starting the server.  If your plugin is correctly loaded, you should see this message as part of the server's initialization output. 
 
 .. code-block:: java
 
@@ -74,21 +76,16 @@ of the :javadoc:`Listener` annotation before the method.
     import com.google.inject.Inject;
     import org.slf4j.Logger;
 
-
     @Plugin(id = "exampleplugin", name = "Example Plugin", version = "1.0", description = "Example")
     public class ExamplePlugin {
 
-        // Logger is automatically assigned to this variable through dependency injection.
-        //  (see the "Logging and Debugging" section in the Sponge documentation for more 
-        //   explanation on logging)
         @Inject
         private Logger logger;
 
         @Listener
         public void onServerStart(GameStartedServerEvent event)
         {
-            // This message will show up in the server output
-            logger.info("MY NEW PLUGIN IS RUNNING!!!");
+            logger.info("Successfully running ExamplePlugin!!!");
         }
 
     }

--- a/source/plugin/plugin-class.rst
+++ b/source/plugin/plugin-class.rst
@@ -64,7 +64,7 @@ Your plugin can listen for particular events, called **state events**, to be not
 game. In the example below, ``onServerStart()`` is called when the :javadoc:`GameStartedServerEvent` occurs; take note
 of the :javadoc:`Listener` annotation before the method.  
 
-The example below will log a message upon starting the server.  If your plugin is correctly loaded,
+The example below will log a message upon starting the server. If your plugin is correctly loaded,
 you should see this message as part of the server's initialization output.
 
 .. code-block:: java


### PR DESCRIPTION
see #644 

when getting started on a new plugin for the first time, one needs a way to verify that it works, and printing one line to a log seems like a good start.   I wanted to update the docs to make this a bit more straightforward since I stumbled on this more than I should have when trying to get things rolling.
