### PR TITLE
Mention signature download url. Fixes #612

### DIFF
--- a/source/ore/routes/download.rst
+++ b/source/ore/routes/download.rst
@@ -2,7 +2,16 @@
 Download Project Version
 ========================
 
+.. note::
+
+    Please note that this endpoint does **not** use an ore web api version infix such as ``/api/v1/``.
+
 **GET /api/projects/:pluginId/versions/:version/download**
 
 Returns a file stream for the specified version within the specified project. The ``:version`` parameter may be replaced
 with ``recommended`` to download the project's current recommended version.
+
+**GET /api/projects/:pluginId/versions/:version/signature**
+
+Returns the pgp signature file stream for the above file. This signature file can be used to verify that the download
+was not modified/corrupted in any way and was uploaded by the correct author.


### PR DESCRIPTION
Fixes #612 

Can someone for the ore team verify that this URL is the recommended one to use?
(Its the only URL/route without a version infix)