### PR TITLE
Use absolute paths instead of relative paths that go through root

### DIFF
--- a/source/about/faq.rst
+++ b/source/about/faq.rst
@@ -21,7 +21,7 @@ What is required to run Sponge?
 
 Sponge (and Minecraft) needs the Java Runtime Environment to run properly. You will obviously need a computer to run
 the server on too, besides that nothing is required. Learn more about choosing and installing the correct Java version
-here: :doc:`../server/getting-started/jre/`
+here: :doc:`/server/getting-started/jre/`
 
 Where do I get Sponge?
 ----------------------
@@ -105,7 +105,7 @@ What can I do with Sponge?
 --------------------------
 
 Sponge provides a Plugin API. This means that you can create new content and gamemodes on the go.
-Have a look at our plugin pages to get a quick-start: :doc:`../plugin/index`
+Have a look at our plugin pages to get a quick-start: :doc:`/plugin/index`
 
 What can't I do with Sponge? / Limitations of Sponge?
 -----------------------------------------------------
@@ -130,4 +130,4 @@ Accessing the server internals (known as "NMS" or "net.minecraft.server" in Craf
 which has a large number of names de-obfuscated. However, be aware that accessing the server internals raises the risk
 of your plugin breaking - this is your prerogative.
 
-See :doc:`../plugin/internals/index` for an introduction about using MCP in your plugin.
+See :doc:`/plugin/internals/index` for an introduction about using MCP in your plugin.

--- a/source/contributing/guidelines.rst
+++ b/source/contributing/guidelines.rst
@@ -14,7 +14,7 @@ make sure you follow our guidelines.
 General steps
 =============
 
-1. Setup your workspace as described in :doc:`../../preparing/index`.
+1. Setup your workspace as described in :doc:`/preparing/index`.
 
 #. Make sure you're familiar with Git and GitHub. If your knowledge needs a refresh, take a look here: :doc:`howtogit`
 

--- a/source/contributing/howtogit.rst
+++ b/source/contributing/howtogit.rst
@@ -7,7 +7,7 @@ then you'll need to become familiar with ``git`` and GitHub. If you're already f
 issues, pull-requests and commits, then just skip this topic. If you have no clue what we're talking about, then read on.
 
 .. note::
-  This guide assumes that you've read :doc:`../preparing/git` and that you've already setup your machine with a Git
+  This guide assumes that you've read :doc:`/preparing/git` and that you've already setup your machine with a Git
   client of your choice.
 
 The Basic Concept of Git and GitHub
@@ -75,7 +75,7 @@ clone is now located at ``YourGitHubAccount/ClonedRepoName``. Alright, first ste
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Now you need to get this fork to your local machine to make your changes. Open the Git Client of your choice
-(:doc:`../preparing/git`) and ``clone`` your fork to your local machine. The client will ask you for a folder to store
+(:doc:`/preparing/git`) and ``clone`` your fork to your local machine. The client will ask you for a folder to store
 everything in. Second step finished, well done!
 
 .. note::

--- a/source/contributing/implementation/codestyle.rst
+++ b/source/contributing/implementation/codestyle.rst
@@ -7,7 +7,7 @@ few additions and modifications, which are described herein.
 
 .. tip::
     You can use our code styles for Eclipse or IntelliJ IDEA to let your IDE format the code correctly for you. See
-    :doc:`../../preparing/index` for more information.
+    :doc:`/preparing/index` for more information.
 
 * Line endings
 

--- a/source/contributing/implementation/datamanipulator.rst
+++ b/source/contributing/implementation/datamanipulator.rst
@@ -368,7 +368,7 @@ whether the operation was successful or not.
 .. tip::
 
     To understand :javadoc:`DataTransactionResult`\s, check the :doc:`corresponding docs page
-    <../../plugin/data/transactions>` and refer to the :javadoc:`DataTransactionResult.Builder` docs to create one.
+    </plugin/data/transactions>` and refer to the :javadoc:`DataTransactionResult.Builder` docs to create one.
 
 .. warning::
 

--- a/source/contributing/index.rst
+++ b/source/contributing/index.rst
@@ -20,7 +20,7 @@ advised before starting any work. There are several projects we're currently mai
 * Ore
 
 If you want to know more about the structure of the project and how everything is tied together, head over to
-:doc:`../about/structure`.
+:doc:`/about/structure`.
 
 What kind of help is needed?
 ============================
@@ -36,7 +36,7 @@ This can be done by almost everyone. You don't need to know a programming langua
 
 Reporting bugs best via our `GitHub repositories <https://github.com/spongepowered/>`_, suggestions fit onto our
 `forums <https://forums.spongepowered.org/>`_. Just have a look at our
-:doc:`Bug Reporting page <../server/spongineer/bugreport>` for further instructions.
+:doc:`Bug Reporting page </server/spongineer/bugreport>` for further instructions.
 
 Intermediate Contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/plugin/configuration/index.rst
+++ b/source/plugin/configuration/index.rst
@@ -22,7 +22,7 @@ files to full advantage.
 .. note::
     Sponge makes use of the HOCON configuration format, a superset of JSON, as the default format for saving
     configuration files. The rest of this guide will assume you are using HOCON as well. See
-    :doc:`../../server/getting-started/configuration/hocon` more for information regarding the HOCON format.
+    :doc:`/server/getting-started/configuration/hocon` more for information regarding the HOCON format.
     Working with different formats is made relatively similar by the Configurate system, so it should not
     pose too much of an issue if you use an alternate format instead.
 

--- a/source/plugin/permissions.rst
+++ b/source/plugin/permissions.rst
@@ -15,8 +15,8 @@ Permissions
 
 
 If you are interested in the permissions that are used in vanilla commands have a look at 
-:doc:`this page <../../server/spongineer/commands>`. For customizing the permission levels refer to the
-:doc:`server permissions <../../server/management/permissions>` page or your permission plugin's documentation.
+:doc:`this page </server/spongineer/commands>`. For customizing the permission levels refer to the
+:doc:`server permissions </server/management/permissions>` page or your permission plugin's documentation.
 
 Permission
 ==========

--- a/source/server/getting-started/configuration/server-properties.rst
+++ b/source/server/getting-started/configuration/server-properties.rst
@@ -52,7 +52,7 @@ Here is the default server.properties file of an unmodified Minecraft 1.8.1 serv
     enable-rcon=false
 
 Property Explanation
-----------------------
+--------------------
 
 Credit goes to the editors at the `Minecraft Wiki <https://minecraft.gamepedia.com>`__ for the explanations.
 
@@ -375,7 +375,7 @@ Credit goes to the editors at the `Minecraft Wiki <https://minecraft.gamepedia.c
 |                               |             |             | *reduce this value.*                                       |
 +-------------------------------+-------------+-------------+------------------------------------------------------------+
 | white-list                    | boolean     | false       | Enables a whitelist on the server.                         |
-|                               |             |             | See :doc:`../../../server/management/whitelist`.           |
+|                               |             |             | See :doc:`/server/management/whitelist`.                   |
 |                               |             |             | With a whitelist enabled, users not on the whitelist will  |
 |                               |             |             | be unable to connect. Intended for private servers, such   |
 |                               |             |             | as those for real-life friends or strangers carefully      |

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -188,7 +188,7 @@ player-moved-too-quickly                  boolean   true        Controls whether
                                                                 will be enforced
 player-vehicle-moved-too-quickly          boolean   true        Controls whether the 'vehicle of player moved too quickly!'
                                                                 check will be enforced
-**Optimizations**                                               See :doc:`../../management/performance-tweaks`
+**Optimizations**                                               See :doc:`/server/management/performance-tweaks`
 **Spawner**
 spawn-limit-ambient                       integer       15          The number of ambients that can spawn around the player.
 spawn-limit-animal                        integer       15          The number of animals that can spawn around the player.

--- a/source/server/management/permissions.rst
+++ b/source/server/management/permissions.rst
@@ -2,7 +2,7 @@
 Managing Permissions
 ====================
 
-You can configure who has access to what if you are running a server by making use of :doc:`../../plugin/permissions`.
+You can configure who has access to what if you are running a server by making use of :doc:`/plugin/permissions`.
 Specific permissions for Sponge, Forge and Minecraft commands are shown on the :doc:`../spongineer/commands` page.
 
 
@@ -13,7 +13,7 @@ Minecraft comes with a simple way to give permissions: by setting users as opera
 information on op status can be found at https://minecraft.gamepedia.com/Op
 
 The abilities of op permission may be adjusted by altering the ``op-permission-level`` setting in the
-:doc:`../../server/getting-started/configuration/server-properties` file.
+:doc:`/server/getting-started/configuration/server-properties` file.
 
 
 A list of native Minecraft server commands available to players with op can be found at the `Minecraft Wiki

--- a/source/server/management/whitelist.rst
+++ b/source/server/management/whitelist.rst
@@ -11,7 +11,7 @@ Players can be added to the whitelist through the usage of in-game :doc:`../spon
 ``whitelist.json`` file. Beware, however: if you manually change the file, you will have to reload the whitelist or
 restart the server for the changes to go into effect. Additionally, pay special heed to the syntax, as the whitelist
 won't work if it is wrong. An example of a correctly formatted whitelist file can be found at
-:doc:`../../server/getting-started/configuration/json`.
+:doc:`/server/getting-started/configuration/json`.
 
 - To enable the whitelist, use ``/whitelist on``
 - To disable the whitelist, use ``/whitelist off``
@@ -21,13 +21,13 @@ won't work if it is wrong. An example of a correctly formatted whitelist file ca
 - To reload the whitelist after a manual change to the file, use ``/whitelist reload``
 
 The whitelist can also be enabled or disabled by editing the
-:doc:`../../server/getting-started/configuration/server-properties` file, although this will only affect the game after
+:doc:`/server/getting-started/configuration/server-properties` file, although this will only affect the game after
 server reload or restart.
 
 Permissions
 ===========
 
-You can also use these :doc:`../../plugin/permissions` to manage the access to your server.
+You can also use these :doc:`/plugin/permissions` to manage the access to your server.
 
 =================================== ====================================================================
 Permission                          Description

--- a/source/server/spongineer/commands.rst
+++ b/source/server/spongineer/commands.rst
@@ -5,7 +5,7 @@ Commands
 Commands are one method in which server operators can administer their server, and in which players can interact with
 the server.
 
-In Sponge, commands follow a system of :doc:`../../plugin/permissions`. Permissions allow server operators to control
+In Sponge, commands follow a system of :doc:`/plugin/permissions`. Permissions allow server operators to control
 who can access what commands. By default, all commands are granted to players with OP status. Players without operator
 status do not have access to administrative commands or commands that require an assigned permission node. A server
 operator can fine-tune who can access what commands by adding/negating permission nodes through a permissions plugin.

--- a/source/server/spongineer/troubleshooting.rst
+++ b/source/server/spongineer/troubleshooting.rst
@@ -13,7 +13,7 @@ and what to do about it.
 Java Is Not Installed On Your Computer
 --------------------------------------
 
-**Solution**: Get Java. Visit the :doc:`../../server/getting-started/jre` for more information.
+**Solution**: Get Java. Visit the :doc:`/server/getting-started/jre` for more information.
 
 Network Connection Failure (or DDoS Attack)
 -------------------------------------------
@@ -62,7 +62,7 @@ each time. The problem may originate from one plugin that is out of date - check
 be the cause, having two incompatible plugins.
 
 Operating System Unstable (eg. Virus Infection)
---------------------------------------------------
+-----------------------------------------------
 
 **Symptom**: The server keeps crashing or timing out, and other parts of your operating system are also having problems.
 


### PR DESCRIPTION
The use of relative paths sometimes makes it more complex to understand where they are actually pointing to and in most cases its just longer. Thats why I think we should use absolute paths for paths that go to the docs root.

On the actual docs page / after compilation it will still use relative paths.