### PR TITLE
Document regex und selector support in CommandElements

### DIFF
--- a/source/plugin/commands/arguments.rst
+++ b/source/plugin/commands/arguments.rst
@@ -17,7 +17,7 @@ Argument Parsing
     java.lang.String
 
 The Command Builder API comes with a powerful argument parser. It converts the string input to java base types
-(integers, booleans, strings) or game objects (players, worlds, block types , ...). The parser supports optional
+(integers, booleans, strings) or game objects (players, worlds, block types, ...). The parser supports optional
 arguments and flags. It also handles TAB completion of arguments.
 
 The parsed arguments are stored in the :javadoc:`CommandContext` object. If the parser returns a single object, obtain
@@ -27,9 +27,9 @@ Many of the parsers may return more than one object (e.g. multiple players with 
 must use the :javadoc:`CommandContext#getAll(String)` method to get the ``Collection`` of possible matches.
 **Otherwise, the context object will throw an exception!**
 
-When creating a command, consider whether the argument could return multiple values, for example, whether a
-player argument could support multiple players when using a selector. If you support multiple values the users need
-to type only one command and can use an easier command syntax. Example: ``/tell @a Who took the cookies?``.
+When creating a command, consider whether the argument could return multiple values, for example, whether a player
+argument could support multiple players when using a selector. If you support multiple values the users need to type
+only one command and can use an easier command syntax. Example: ``/tell @a Who took the cookies?``
 
 .. tip::
 
@@ -41,7 +41,7 @@ To create a new :javadoc:`CommandElement` (argument), use the :javadoc:`GenericA
 elements require a short text key, which is displayed in error and help messages.
 
 Apply the ``CommandElement`` to the command builder with the :javadoc:`CommandSpec.Builder#arguments(CommandElement...)`
-method. It is possible to pass more than one ``CommandElement`` to the method, thus chaining multiple arguments (e.g
+method. It is possible to pass more than one ``CommandElement`` to the method, thus chaining multiple arguments (e.g.
 ``/msg <player> <msg>``). This has the same effect as wrapping the ``CommandElement`` objects in a
 :javadoc:`GenericArguments#seq(CommandElement...)` element.
 

--- a/source/plugin/commands/arguments.rst
+++ b/source/plugin/commands/arguments.rst
@@ -25,15 +25,17 @@ it with :javadoc:`CommandContext#getOne(String)`. Optional and weak arguments ma
 
 Many of the parsers may return more than one object (e.g. multiple players with a matching username). In that case, you
 must use the :javadoc:`CommandContext#getAll(String)` method to get the ``Collection`` of possible matches.
-**Otherwise, the context object will throw an exception!** Please make sure that you make a conscious decision whether
-you need to limit your ``CommandExecutor`` to a single result or can support multiple arguments. If you support multiple
-arguments the users have to type less and shorter commands. Example: ``/tell @a Who took the cookies?``.
+**Otherwise, the context object will throw an exception!**
+
+When creating a command, consider whether the argument could return multiple values, for example, whether a
+player argument could support multiple players when using a selector. If you support multiple values the users need
+to type only one command and can use an easier command syntax. Example: ``/tell @a Who took the cookies?``.
 
 .. tip::
 
-   You can use the :javadoc:`GenericArguments#onlyOne(CommandElement)` element to limit the amount of returned values to
-   a single one, so you can safely use ``args.<T>getOne(String)``. However the user will still get a message, if he
-   tries to select more than one value.
+   You can use the :javadoc:`GenericArguments#onlyOne(CommandElement)` element to restrict the amount of returned values
+   to a single one, so you can safely use ``args.<T>getOne(String)``. However the user will still get a message, if they
+   try to select more than one value.
 
 To create a new :javadoc:`CommandElement` (argument), use the :javadoc:`GenericArguments` factory class. Many command
 elements require a short text key, which is displayed in error and help messages.
@@ -168,9 +170,10 @@ Overview of the ``GenericArguments`` command elements
 
 .. warning::
 
-    Some of these ``CommandElement``\s support multiple return values; some might event support regular expressions or
-    use a command selector. This is intentional as it makes commands easier to use. Example:
-    ``/tell @a BanditPlayer has the cookies!``.
+    Don't expect that a ``CommandElement``\s will only ever return a single value, a lot of them support multiple return
+    values; some might even support regular expressions or use a command selector. This is intentional as it makes
+    commands easier to use. Example: ``/tell @a BanditPlayer has the cookies!``. If you want to make sure to only get a
+    single value use ``GenericArguments#onlyOne(CommandElement)``.
 
 Custom Command Elements
 =======================

--- a/source/plugin/commands/arguments.rst
+++ b/source/plugin/commands/arguments.rst
@@ -25,13 +25,15 @@ it with :javadoc:`CommandContext#getOne(String)`. Optional and weak arguments ma
 
 Many of the parsers may return more than one object (e.g. multiple players with a matching username). In that case, you
 must use the :javadoc:`CommandContext#getAll(String)` method to get the ``Collection`` of possible matches.
-**Otherwise, the context object will throw an exception!**
+**Otherwise, the context object will throw an exception!** Please make sure that you make a conscious decision whether
+you need to limit your ``CommandExecutor`` to a single result or can support multiple arguments. If you support multiple
+arguments the users have to type less and shorter commands. Example: ``/tell @a Who took the cookies?``.
 
 .. tip::
 
-   You can use the
-   :javadoc:`GenericArguments#onlyOne(CommandElement)` element to limit the amount of returned values to a single one,
-   so you can safely use ``args.<T>getOne(String)``.
+   You can use the :javadoc:`GenericArguments#onlyOne(CommandElement)` element to limit the amount of returned values to
+   a single one, so you can safely use ``args.<T>getOne(String)``. However the user will still get a message, if he
+   tries to select more than one value.
 
 To create a new :javadoc:`CommandElement` (argument), use the :javadoc:`GenericArguments` factory class. Many command
 elements require a short text key, which is displayed in error and help messages.
@@ -65,17 +67,14 @@ Example: Building a Command with Multiple Arguments
                     GenericArguments.onlyOne(GenericArguments.player(Text.of("player"))),
                     GenericArguments.remainingJoinedStrings(Text.of("message")))
 
-            .executor(new CommandExecutor() {
-                @Override
-                public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+            .executor((CommandSource src, CommandContext args) -> {
 
-                    Player player = args.<Player>getOne("player").get();
-                    String message = args.<String>getOne("message").get();
+                Player player = args.<Player>getOne("player").get();
+                String message = args.<String>getOne("message").get();
 
-                    player.sendMessage(Text.of(message));
+                player.sendMessage(Text.of(message));
 
-                    return CommandResult.success();
-                }
+                return CommandResult.success();
             })
             .build();
 
@@ -166,6 +165,12 @@ Overview of the ``GenericArguments`` command elements
 .. tip::
 
     See the Javadocs for :javadoc:`GenericArguments` for more information.
+
+.. warning::
+
+    Some of these ``CommandElement``\s support multiple return values; some might event support regular expressions or
+    use a command selector. This is intentional as it makes commands easier to use. Example:
+    ``/tell @a BanditPlayer has the cookies!``.
 
 Custom Command Elements
 =======================

--- a/source/plugin/commands/index.rst
+++ b/source/plugin/commands/index.rst
@@ -1,6 +1,6 @@
-========
-Commands
-========
+===============
+Plugin Commands
+===============
 
 .. javadoc-import::
 	org.spongepowered.api.command.CommandCallable


### PR DESCRIPTION
Fixes #309

* Add explicit warning that there is regex and selector support there.
* Also use lambda for better readability
* Change title to `Plugin Commands` for disambiguation in the search.