### PR TITLE
Start working on the metrics collection docs.

### DIFF
--- a/source/plugin/index.rst
+++ b/source/plugin/index.rst
@@ -53,6 +53,7 @@ Contents
     database
     permissions
     bans
+    metrics
     bookview
     economy/index
     wgen/index

--- a/source/plugin/metrics.rst
+++ b/source/plugin/metrics.rst
@@ -54,6 +54,7 @@ The following example shows how to use field injections to get the ``MetricsConf
 .. code-block:: java
 
     import com.google.inject.Inject;
+    import org.spongepowered.api.plugin.PluginContainer;
     import org.spongepowered.api.util.metric.MetricsConfigManager;
 
     @Inject

--- a/source/plugin/metrics.rst
+++ b/source/plugin/metrics.rst
@@ -8,7 +8,7 @@ Metrics Collection
     org.spongepowered.api.util.metric.MetricsConfigManager
 
 Collection of metrics from servers that use your plugin can be an incredibly useful tool for knowing what direction
-to take your plugin in. However, the :doc:`/ore/guidelines` (under External Connections) state that plugins may
+to take your plugin in. However, the :doc:`/ore/guidelines` (under External Connections) state that plugins may only
 collect metrics if informed consent has been granted. Such consent must be **opt-in**, metrics collection must be off
 by default.
 
@@ -21,7 +21,7 @@ Obtaining Consent
 =================
 
 In order to gain consent from server owners, plugins may request that server owners enable metrics. This can be
-of the form of a message on startup instructing the playes that they can enable metrics by updating the configuration
+of the form of a message on startup instructing the players that they can enable metrics by updating the configuration
 option in configuration files. SpongeForge and SpongeVanilla also provide the ``/sponge metrics <pluginid> enable``
 command.
 

--- a/source/plugin/metrics.rst
+++ b/source/plugin/metrics.rst
@@ -1,0 +1,67 @@
+==================
+Metrics Collection
+==================
+
+.. javadoc-import::
+    org.spongepowered.api.Sponge
+    org.spongepowered.api.plugin.PluginContainer
+    org.spongepowered.api.util.metric.MetricsConfigManager
+
+Collection of metrics from servers that use your plugin can be an incredibly useful tool for knowing what direction
+to take your plugin in. However, the :doc:`/ore/guidelines` (under External Connections) state that plugins may
+collect metrics if informed consent has been granted. Such consent must be **opt-in**, metrics collection must be off
+by default.
+
+To simplify gathering consent, Sponge provides an API that allow plugins to check for this consent in a central way.
+
+Metrics collection consent is on a per-plugin basis. Plugins **must not** assume that consent for one plugin means
+consent for all.
+
+Obtaining Consent
+=================
+
+In order to gain consent from server owners, plugins may request that server owners enable metrics. This can be
+of the form of a message on startup instructing the playes that they can enable metrics by updating the configuration
+option in configuration files. SpongeForge and SpongeVanilla also provide the ``/sponge metrics <pluginid> enable``
+command.
+
+Plugins **may** prompt server owners to run the command or allow for a "one click" enable in game.
+
+.. warning::
+    Plugins **may not** run the ``/sponge metrics <pluginid> enable`` command without a server owner's informed
+    consent. Doing so will cause a plugin to be rejected from the Ore platform.
+
+.. note::
+    The ``/sponge metrics`` command is only guaranteed to exist on the ``SpongeForge`` and ``SpongeVanilla`` server
+    implementations. Other implementations, such as ``Lantern``, may not include this command.
+
+Checking for Consent
+====================
+
+The :javadoc:`MetricsConfigManager` allows you to determine if your plugin has gained consent to send metrics. This
+can either be injected into your plugin class, or obtained via :javadoc:`Sponge#getMetricsConfigManager()` object
+on demand.
+
+**Every time** your plugin wishes to send metrics, you must check the
+:javadoc:`MetricsConfigManager#areMetricsEnabled(PluginContainer)`, supplying the :javadoc:`PluginContainer` of
+your plugin. Metrics must only be sent if this returns ``true`` for your plugin.
+
+The following example shows how to use field injections to get the ``MetricsConfigManager`` and the
+``PluginContainer`` for your plugin, and uses those to determine whether consent to send metrics has been obtained.
+
+**Example**
+
+.. code-block:: java
+
+    import com.google.inject.Inject;
+    import org.spongepowered.api.util.metric.MetricsConfigManager;
+
+    @Inject
+    private PluginContainer container;
+
+    @Inject
+    private MetricsConfigManager metricsConfigManager;
+
+    public boolean hasConsent() {
+        return this.metricsConfigManager.areMetricsEnabled(this.container);
+    }

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -243,6 +243,14 @@ log-stacktraces
 world-auto-save
     Log when a world auto-saves its chunk data. Note: This may be spammy depending on the auto-save-interval configured for world.
 
+metrics-collection
+==================
+
+default-permission
+    Determines whether newly added plugins can collect server metrics by default
+plugin-permissions
+    Per-plugin toggles indicating whether a plugin is allowed to collect server metrics
+
 modules
 =======
 

--- a/source/server/spongineer/commands.rst
+++ b/source/server/spongineer/commands.rst
@@ -42,6 +42,9 @@ Command                 Description                                Permission
                         information about the entity you are
                         looking at.
 /sponge heap            Dumps the JVM heap.                        sponge.command.heap
+/sponge metrics         Gets or sets whether metric (also known    sponge.command.metrics
+                        as server stats) collection is enabled
+                        for a given plugin.
 /sponge mods            Lists currently installed forge mods.      sponge.command.mods
                         (SpongeForge only)
 /sponge plugins         Lists currently installed Sponge plugins.  sponge.command.plugins
@@ -57,7 +60,7 @@ Command                 Description                                Permission
                         the console.
 /sponge which           Prints which plugin provided the command,  sponge.command.which
                         it's aliases and alternatives.
-/sponge:callback        Internally used for callback actions on 
+/sponge:callback        Internally used for callback actions on
                         ``Text``\s (such as pagination). Not
                         intended to be invoked by hand.
 /sponge:help            View information on commands used on the   sponge.command.help
@@ -75,15 +78,15 @@ Command                 Description                                Permission
 
 **Command Conflicts**
 
-In cases of command conflict, Sponge provides a primary alias mechanism to specify which command is to be used.  For 
-example, Minecraft provides the `reload <https://minecraft.gamepedia.com/Commands#Summary_of_commands>`__ command and 
-Sponge provides the `reload <https://docs.spongepowered.org/stable/en/server/spongineer/commands.html>`__ command. To 
-specify which command to use, prefix it with ``minecraft`` or ``sponge`` and a ``:``. So, to use Sponge's reload command 
+In cases of command conflict, Sponge provides a primary alias mechanism to specify which command is to be used.  For
+example, Minecraft provides the `reload <https://minecraft.gamepedia.com/Commands#Summary_of_commands>`__ command and
+Sponge provides the `reload <https://docs.spongepowered.org/stable/en/server/spongineer/commands.html>`__ command. To
+specify which command to use, prefix it with ``minecraft`` or ``sponge`` and a ``:``. So, to use Sponge's reload command
 above, type in ``/sponge:reload``. This approach can also be used to handle conflicts between mods and/or plugins. Do
 the same thing, just use the mod-id or the plugin-id and a ``:``.  An example is ``/examplemodid:tp``.
 
-Furthermore, the primary alias mechanism can be used to overcome incompatibilities. Let's say a plugin registers a 
-command, but the command is incompatible with your mod. If you can configure your mod to use a Minecraft native 
+Furthermore, the primary alias mechanism can be used to overcome incompatibilities. Let's say a plugin registers a
+command, but the command is incompatible with your mod. If you can configure your mod to use a Minecraft native
 command or another plugin's command, you can restore the expected behavior or prevent unexpected behaviors.
 
 .. note::
@@ -215,7 +218,7 @@ Sponge also creates permissions for these Minecraft features:
 
 .. note::
 
-    These permissions use the actual *name* of the commandblock, which is normally ``@`` by default. 
+    These permissions use the actual *name* of the commandblock, which is normally ``@`` by default.
 
 There are also extra permissions managing the access to the server:
 
@@ -227,7 +230,7 @@ There are also extra permissions managing the access to the server:
     Sponge offers improved multi-world support, such as per-world world borders. By default, Sponge only changes the
     world border (or other world options) of the world the player is currently in. The vanilla behavior of setting it
     for all worlds can be restored using the global configuration and setting
-    ``sponge.commands.multi-world-patches.worldborder`` (or the corresponding entry) to ``false``. See 
+    ``sponge.commands.multi-world-patches.worldborder`` (or the corresponding entry) to ``false``. See
     :doc:`/server/getting-started/configuration/sponge-conf` for details. Sponge assumes that multi-world plugins also
     provide optimized configuration commands for those options and thus does not provide its own variants.
 


### PR DESCRIPTION
After the merge of the Metrics Collection API for Ore, it's prudent that we document it!

I've added the basics so far, but I have more to do. Specifically:

* Add docs on what this section is in a bit more detail for a server admin, so they know that plugins downloaded from Ore have metrics collection off by default (maybe? Wanted? Where should it go?)
* Add docs on the API for plugin developers, including a link to the Ore guidelines (and maybe @mbax will want to chime in with thoughts on what we should add)

I'll do this over the next few days, uploading what I have now. Mostly want this visible so you know it's being worked on.

(Some line endings seem to have changed, probably because I'm on Windows at the moment. I'll have to look into that...)