### PR TITLE
Extend plugin configuration docs. Fixes #735. Fixes #553

### DIFF
--- a/source/plugin/configuration/index.rst
+++ b/source/plugin/configuration/index.rst
@@ -4,8 +4,8 @@ Configuring Plugins
 
 .. javadoc-import::
     ninja.leaping.configurate.hocon.HoconConfigurationLoader
-    ninja.leaping.configurate.yaml.YAMLConfigurationLoader
     ninja.leaping.configurate.gson.GsonConfigurationLoader
+    ninja.leaping.configurate.yaml.YAMLConfigurationLoader
     org.spongepowered.api.config.ConfigDir
     org.spongepowered.api.config.DefaultConfig
 
@@ -52,6 +52,10 @@ Getting your Default Plugin Configuration
 
 SpongeAPI offers the use of the :javadoc:`DefaultConfig` annotation on a field or setter method with the type
 ``Path`` to get the default configuration file for your plugin.
+
+If you place the ``@DefaultConfig`` annotation on a field with the type ``ConfigurationLoader`` then you can use it to 
+load and save the default config file in the file system. Please keep in mind that the annotated ``ConfigurationLoader``
+does not use any default config file that you might ship with your jar, unless you explicitly load it.
 
 The ``@DefaultConfig`` annotation requires a ``sharedRoot`` boolean. If you set ``sharedRoot`` to ``true``, then the
 returned pathname will be in a shared configuration directory. In that case, the configuration file for your plugin

--- a/source/plugin/configuration/index.rst
+++ b/source/plugin/configuration/index.rst
@@ -5,6 +5,7 @@ Configuring Plugins
 .. javadoc-import::
     ninja.leaping.configurate.hocon.HoconConfigurationLoader
     ninja.leaping.configurate.yaml.YAMLConfigurationLoader
+    ninja.leaping.configurate.gson.GsonConfigurationLoader
     org.spongepowered.api.config.ConfigDir
     org.spongepowered.api.config.DefaultConfig
 
@@ -107,6 +108,7 @@ specific directory or to ``true`` to get the shared configuration directory.
 
 .. note::
 
-    The use of YAML format (http://yaml.org/spec/1.1/) is also supported, but the preferred config format for Sponge
-    plugins is HOCON. Conversion from YAML to HOCON can be automated by using a :javadoc:`YAMLConfigurationLoader` to
-    load the old config and then saving it using a :javadoc:`HoconConfigurationLoader`.
+    The use of YAML format (http://yaml.org/spec/1.1/) and JSON format (https://www.json.org/) is also supported, but
+    the preferred config format for Sponge plugins is HOCON. Conversion from YAML (or JSON) to HOCON can be automated by
+    using a :javadoc:`YAMLConfigurationLoader` (or :javadoc:`GsonConfigurationLoader`) to load the old config and then
+    saving it using a :javadoc:`HoconConfigurationLoader`.

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -57,7 +57,7 @@ and store it in a variable.
 
 Of course, this isn't the only way to load a file. The builder also has the method
 :javadoc:`AbstractConfigurationLoader.Builder#setPath(URL) {setURL(url)}`, in case you want
-to load a resource without using a :javadoc:`Path` object. Bear in mind that configuration loaders created from an
+to load a resource without using a :javadoc:`Path` object. Bear in mind that configuration loaders created from a
 :javadoc:`URL` are read-only as they have no way of writing back data to the URL.
 
 This functionality may be used to bundle default configurations with your plugin jar file and load them as initial
@@ -68,7 +68,6 @@ configuration to be edited by the server administrator (or your plugin itself).
     This example uses a ``HoconConfigurationLoader``, which is the recommended approach for Sponge plugins, but
     you can also use a :javadoc:`YAMLConfigurationLoader` or :javadoc:`GsonConfigurationLoader` for loading legacy
     configs.
-
 
 Loading and Saving
 ~~~~~~~~~~~~~~~~~~

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -56,7 +56,7 @@ We then tell the builder to build the instance (:javadoc:`HoconConfigurationLoad
 and store it in a variable.
 
 Of course, this isn't the only way to load a file. The builder also has the method
-:javadoc:`AbstractConfigurationLoader.Builder#setPath(URL) {setURL(url)}`, in case you want
+:javadoc:`AbstractConfigurationLoader.Builder#setURL(URL) {setURL(url)}`, in case you want
 to load a resource without using a :javadoc:`Path` object. Bear in mind that configuration loaders created from a
 :javadoc:`URL` are read-only as they have no way of writing back data to the URL.
 

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -41,7 +41,7 @@ First, let's grab a new :javadoc:`HoconConfigurationLoader` that points to our c
 
     Path potentialFile = getConfigPath();
     ConfigurationLoader<CommentedConfigurationNode> loader =
-      HoconConfigurationLoader.builder().setPath(potentialFile).build();
+            HoconConfigurationLoader.builder().setPath(potentialFile).build();
 
 The loader will also hold a generic type depending what kind of node it will build. These *Configuration Nodes* will be
 discussed in :doc:`a later section <nodes>`.
@@ -73,7 +73,8 @@ Once you obtained your ``ConfigurationLoader`` you can use it to obtain an empty
     import ninja.leaping.configurate.ConfigurationOptions;
 
     Path potentialFile = getConfigPath();
-    ConfigurationLoader<CommentedConfigurationNode> loader = HoconConfigurationLoader.builder().setPath(potentialFile).build();
+    ConfigurationLoader<CommentedConfigurationNode> loader =
+            HoconConfigurationLoader.builder().setPath(potentialFile).build();
     ConfigurationNode rootNode = loader.createEmptyNode(ConfigurationOptions.defaults());
 
 This method expects the :javadoc:`ConfigurationOptions` to use as a parameter. Unless you want to use
@@ -90,7 +91,8 @@ but also provides a no-args form that is shorthand for
     import java.io.IOException;
 
     Path potentialFile = getConfigPath();
-    ConfigurationLoader<CommentedConfigurationNode> loader = HoconConfigurationLoader.builder().setPath(potentialFile).build();
+    ConfigurationLoader<CommentedConfigurationNode> loader =
+            HoconConfigurationLoader.builder().setPath(potentialFile).build();
     ConfigurationNode rootNode;
     try {
         rootNode = loader.load();
@@ -127,7 +129,7 @@ Example: Loading a default config from the plugin jar file
 
     URL jarConfigFile = Sponge.getAssetManager().getAsset("defaultConfig.conf").get().getUrl();
     ConfigurationLoader<CommentedConfigurationNode> loader =
-      HoconConfigurationLoader.builder().setURL(jarConfigFile).build();
+            HoconConfigurationLoader.builder().setURL(jarConfigFile).build();
 
 For this example it is important to note that the :javadoc:`AssetManager#getAsset(String)` method works relative to the
 plugin's asset folder. So, if in the above example the plugin ID is ``myplugin``, the ``defaultConfig.conf`` file

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -19,12 +19,16 @@ Let's break down how Configurate works, beginning with the loading process. Conf
 configuration file, allowing you to save and load data from the given resource. They also allow you to load empty
 configurations, giving you the option of hard-coding default values or loading from a pre-written file.
 
+.. tip::
+
+    The default and recommended config format for Sponge plugins is HOCON.
+
 Getting your Loader
 ~~~~~~~~~~~~~~~~~~~
 
 .. note::
-    The default :javadoc:`ConfigurationLoader` can be used instead if you're using HOCON; see the 
-    :doc:`main configuration page <index>`.
+    The default :javadoc:`ConfigurationLoader` can be used instead if you're using only a single HOCON config file;
+    see the :doc:`main configuration page <index>`.
 
 First, let's grab a new :javadoc:`HoconConfigurationLoader` that points to our configuration file.
 

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -163,5 +163,5 @@ must not lie in the jar file root, but instead in the directory ``assets/myplugi
     ``Optional<Asset>.get()`` method. Please make sure that you configure your :doc:`build system </plugin/buildsystem>`
     to include it in the jar.
 
-If you have an extra configuration class you can use a much easier approach, that also works if the only a part of your
+If you have an extra configuration class, you can use a much easier approach that also works if the only a part of your
 config is missing. See also the examples on the :doc:`serialization` page.

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -6,12 +6,16 @@ Configuration Loaders
     ninja.leaping.configurate.ConfigurationNode
     ninja.leaping.configurate.ConfigurationOptions
     ninja.leaping.configurate.hocon.HoconConfigurationLoader
+    ninja.leaping.configurate.hocon.HoconConfigurationLoader.Builder
+    ninja.leaping.configurate.loader.AbstractConfigurationLoader.Builder
     ninja.leaping.configurate.loader.ConfigurationLoader
     org.spongepowered.api.asset.AssetManager
     java.lang.String
+    java.net.URL
+    java.nio.file.Path
 
 Let's break down how Configurate works, beginning with the loading process. Configurate provides
-:javadoc:`ConfigurationLoader`\ s for common configuration formats, standing as the manager of the physical
+:javadoc:`ConfigurationLoader`\s for common configuration formats, standing as the manager of the physical
 configuration file, allowing you to save and load data from the given resource. They also allow you to load empty
 configurations, giving you the option of hard-coding default values or loading from a pre-written file.
 
@@ -38,15 +42,17 @@ First, let's grab a new :javadoc:`HoconConfigurationLoader` that points to our c
 The loader will also hold a generic type depending what kind of node it will build. These *Configuration Nodes* will be
 discussed in :doc:`a later section <nodes>`.
 
-``ConfigurationLoader``\ s usually hold a builder for you to statically access and create a new instance of the loader of
+``ConfigurationLoader``\s usually hold a builder for you to statically access and create a new instance of the loader of
 your desired type. For a basic configuration, we don't really need to specify anything other than the file we want to
 load from and/or save to, so all we'll do is tell it exactly that, using
-``HoconConfigurationLoader.builder().setPath(path)``. We then tell the builder to build the instance (``build()``) for
-it and store it in a variable.
+:javadoc:`AbstractConfigurationLoader.Builder#setPath(Path) {HoconConfigurationLoader.builder().setPath(path)}`.
+We then tell the builder to build the instance (:javadoc:`HoconConfigurationLoader.Builder#build() {build()}`) for it
+and store it in a variable.
 
-Of course, this isn't the only way to load a file. The builder also has the method ``setURL(URL)``, in case you want
-to load a resource without using a ``Path`` object. Bear in mind that configuration loaders created from an ``URL``
-are read-only as they have no way of writing back data to the URL.
+Of course, this isn't the only way to load a file. The builder also has the method
+:javadoc:`AbstractConfigurationLoader.Builder#setPath(URL) {setURL(url)}`, in case you want
+to load a resource without using a :javadoc:`Path` object. Bear in mind that configuration loaders created from an
+:javadoc:`URL` are read-only as they have no way of writing back data to the URL.
 
 This functionality may be used to bundle default configurations with your plugin jar file and load them as initial
 configuration to be edited by the server administrator (or your plugin itself).
@@ -55,7 +61,7 @@ Loading and Saving
 ~~~~~~~~~~~~~~~~~~
 
 Once you obtained your ``ConfigurationLoader`` you can use it to obtain an empty :javadoc:`ConfigurationNode` using the
-``createEmptyNode()`` method.
+:javadoc:`ConfigurationLoader#createEmptyNode() {createEmptyNode()}` method.
 
 .. code-block:: java
 
@@ -66,13 +72,14 @@ Once you obtained your ``ConfigurationLoader`` you can use it to obtain an empty
     ConfigurationLoader<CommentedConfigurationNode> loader = HoconConfigurationLoader.builder().setPath(potentialFile).build();
     ConfigurationNode rootNode = loader.createEmptyNode(ConfigurationOptions.defaults());
 
-This method expects the `ninja.leaping.configurate.ConfigurationOptions` to use as a parameter. Unless you want to use
+This method expects the :javadoc:`ConfigurationOptions` to use as a parameter. Unless you want to use
 features like custom type serialization, you can just use :javadoc:`ConfigurationOptions#defaults()` to create an
 options object with default values.
 
-Using the ``load()`` method you can attempt to load the configuration contents from the source specified upon creation
-of the ``ConfigurationLoader``. It also expects a ``ConfigurationOptions`` instance, but also provides a no-args form
-that is shorthand for ``load(ConfigurationOptions.defaults())``.
+Using the :javadoc:`ConfigurationLoader#load() {load()}` method you can attempt to load the configuration contents from
+the source specified upon creation of the ``ConfigurationLoader``. It also expects a ``ConfigurationOptions`` instance,
+but also provides a no-args form that is shorthand for
+:javadoc:`ConfigurationLoader#load(ConfigurationOptions) {load(ConfigurationOptions.defaults())}`.
 
 .. code-block:: java
 
@@ -84,7 +91,7 @@ that is shorthand for ``load(ConfigurationOptions.defaults())``.
     try {
         rootNode = loader.load();
     } catch(IOException e) {
-        // error
+        // handle error
     }
 
 If the ``Path`` given does not exist, the ``load()`` method will create an empty ``ConfigurationNode``. Any other error
@@ -102,7 +109,7 @@ it will be created. If it does exist, all contents will be overwritten.
     try {
         loader.save(rootNode);
     } catch(IOException e) {
-        // error
+        // handle error
     }
 
 Again, errors will be propagated as an ``IOException`` and must be handled.

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -131,7 +131,7 @@ Again, errors will be propagated as an ``IOException`` and must be handled.
 
 .. tip::
 
-    It is recommended to save the config after loading it (for the first time after an update) to ensure that newly
+    We recommend saving the config after loading it (for the first time after an update) to ensure that newly
     added or migrated configuration options are written to disk. If you need to save the config afterwards it is
     strongly recommended to do this outside of the main thread. See also common :doc:`/plugin/practices/bad` you should
     avoid.

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -129,6 +129,13 @@ it will be created. If it does exist, all contents will be overwritten.
 
 Again, errors will be propagated as an ``IOException`` and must be handled.
 
+.. tip::
+
+    It is recommended to save the config after loading it (for the first time after an update) to ensure that newly
+    added or migrated configuration options are written to disk. If you need to save the config afterwards it is
+    strongly recommended to do this outside of the main thread. See also common :doc:`/plugin/practices/bad` you should
+    avoid.
+
 Example: Loading a Default Config from the Plugin Jar File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -129,7 +129,7 @@ it will be created. If it does exist, all contents will be overwritten.
 
 Again, errors will be propagated as an ``IOException`` and must be handled.
 
-Example: Loading a default config from the plugin jar file
+Example: Loading a Default Config from the Plugin Jar File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: java
@@ -155,3 +155,6 @@ must not lie in the jar file root, but instead in the directory ``assets/myplugi
     If the config file cannot be found inside your plugin jar, then you will get a ``NoSuchElementException`` from the
     ``Optional<Asset>.get()`` method. Please make sure that you configure your :doc:`build system </plugin/buildsystem>`
     to include it in the jar.
+
+If you have an extra configuration class you can use a much easier approach, that also works if the only a part of your
+config is missing. See also the examples on the :doc:`serialization` page.

--- a/source/plugin/configuration/loaders.rst
+++ b/source/plugin/configuration/loaders.rst
@@ -142,7 +142,7 @@ Example: Loading a default config from the plugin jar file
         URL jarConfigFile = Sponge.getAssetManager().getAsset("defaultConfig.conf").get().getUrl();
         ConfigurationLoader<CommentedConfigurationNode> defaultLoader =
                 HoconConfigurationLoader.builder().setURL(jarConfigFile).build();
-        rootNode.setValue(defaultLoader.load());
+        rootNode = defaultLoader.load();
     }
 
 For this example it is important to note that the :javadoc:`AssetManager#getAsset(String)` method works relative to the

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -8,6 +8,7 @@ Configuration Nodes
     ninja.leaping.configurate.loader.ConfigurationLoader
     ninja.leaping.configurate.objectmapping.serialize.TypeSerializer
     java.lang.Object
+    org.spongepowered.api.util.TypeTokens
 
 In memory, the configuration is represented using :javadoc:`ConfigurationNode`\ s. A ``ConfigurationNode`` either holds
 a value (like a number, a string or a list) or has child nodes, a tree-like configuration structure. When using a
@@ -140,13 +141,26 @@ even generic types can conveniently be written and read.
     For more information about ``TypeToken``\ s, refer to the `guava documentation
     <https://github.com/google/guava/wiki/ReflectionExplained>`_
 
-The types serializable using those methods are:
+.. tip::
+
+	The SpongeAPI provides a :javadoc:`TypeTokens {class}` with many pre-defined type tokens that you can use.
+	If plugin developers need many different or complex ``TypeToken``\s, or use them frequently, it is recommended
+	to create a similar class for themselves to improve code readability. (It is not guaraneteed that all of those
+	entries have registed ``TypeSerializer``\s.)
+
+The following types can be (de-)serialized using those methods:
 
 * Any basic value (see above)
-* Any ``List`` or ``Map`` of serializable types
+* Any ``List``, ``Set`` or ``Map`` of serializable types
+* Any enum or :doc:`CatalogType </plugin/data/catalog-types>`
 * The types ``java.util.UUID``, ``java.net.URL``, ``java.net.URI`` and ``java.util.regex.Pattern``
+* The types ``Text``, the ``TextFormat`` and ``TextTemplate``
 * Any type that has been made serializable as described on :doc:`the config serialization page <serialization>`
 
+.. warning::
+
+    If you need special constraints or rules for your serialization (such as retaining the order in a ``Set``),
+    then you should consider using your own ``TypeSerializer`` implementations.
 
 Defaults
 ~~~~~~~~

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -127,7 +127,7 @@ value into a ``UUID``. The ``TypeSerializer`` (and by extension the above method
 :javadoc:`ObjectMappingException` if it encounters incomplete or invalid data.
 
 Now if we want to write a new ``UUID`` to that config node, the syntax is very similar. Use the
-:javadoc:`ConfigurationNode#setValue(TypeToken type, Object value) {setValue(...)}`
+:javadoc:`ConfigurationNode#setValue(TypeToken, Object) {setValue(...)}`
 method with a ``TypeToken`` and the object you want to serialize.
 
 .. code-block:: java

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -182,7 +182,7 @@ that is the value specified on the config. Unless we specify ``true`` as the def
 
 .. code-block:: java
 
-    boolean shouldEnable = rootNode.getNode("modules", "blockCheats", "enabled").getBoolean(true);
+    boolean shouldEnable = rootNode.getNode("modules", "blockCheats", "enabled") .getBoolean(true);
 
 Similarly, you can specify defaults on any value you get from the config, thus avoiding ``null`` returns or
 ``ObjectMappingException`` caused by the absence of the whole value. It also works on the deserializing ``getValue()``
@@ -190,13 +190,15 @@ method. Some examples:
 
 .. code-block:: java
 
-    String greeting = rootNode.getNode("messages", "greeting").getString("FLARD be with you good man!");
+    String greeting = rootNode.getNode("messages", "greeting")
+            .getString("FLARD be with you good man!");
 
     UUID mayor = rootNode.getNode("towns", "aFLARDia", "mayor")
-                            .getValue(TypeToken.of(UUID.class), somePlayer.getUniqueId());
+            .getValue(TypeToken.of(UUID.class), somePlayer.getUniqueId());
 
 Another useful application of those defaults is that they can be copied to your configuration if needed. Upon creation
-of your root configuration node, you can create your ``ConfigurationOptions`` with ``setShouldCopyDefaults(true)``.
+of your root configuration node, you can create your ``ConfigurationOptions`` with
+:javadoc:`ConfigurationOptions#setShouldCopyDefaults(boolean) {setShouldCopyDefaults(true)}`.
 Subsequently, whenever you provide a default value, Configurate will first check if the value you're trying to get is
 present, and if it is not, it will first write your default value to the node before returning the default value.
 

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -192,7 +192,7 @@ method. Some examples:
             .getString("FLARD be with you good man!");
 
     UUID mayor = rootNode.getNode("towns", "aFLARDia", "mayor")
-            .getValue(TypeToken.of(UUID.class), somePlayer.getUniqueId());
+            .getValue(TypeTokens.UUID_TOKEN, somePlayer.getUniqueId());
 
 Another useful application of those defaults is that they can be copied to your configuration if needed. Upon creation
 of your root configuration node, you can create your ``ConfigurationOptions`` with

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -148,19 +148,9 @@ even generic types can conveniently be written and read.
 	to create a similar class for themselves to improve code readability. (It is not guaranteed that all of those
 	entries have registered ``TypeSerializer``\s.)
 
-The following types can be (de-)serialized using those methods:
+You can find a non-exhaustive list of supported types, and ways to add support for new types on the
+:doc:`the config serialization page <serialization>`.
 
-* Any basic value (see above)
-* Any ``List``, ``Set`` or ``Map`` of serializable types
-* Any enum or :doc:`CatalogType </plugin/data/catalog-types>`
-* The types ``java.util.UUID``, ``java.net.URL``, ``java.net.URI`` and ``java.util.regex.Pattern``
-* The types ``Text``, the ``TextFormat`` and ``TextTemplate``
-* Any type that has been made serializable as described on :doc:`the config serialization page <serialization>`
-
-.. warning::
-
-    If you need special constraints or rules for your serialization (such as retaining the order in a ``Set``),
-    then you should consider using your own ``TypeSerializer`` implementations.
 
 Defaults
 ~~~~~~~~

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -19,8 +19,9 @@ In memory, the configuration is represented using :javadoc:`ConfigurationNode`\ 
 a value (like a number, a string or a list) or has child nodes, a tree-like configuration structure. When using a
 :javadoc:`ConfigurationLoader` to load or create new configurations, it will return the **root node**. It is
 recommended that you always keep a reference to that root node stored somewhere, to prevent loading the configuration
-every time you need to access it and retaining the comments. As an alternative, you could store a reference to a
-:doc:`serializable config instance <serialization>` that holds the entire configuration of your plugin.
+every time you need to access it. As a side effect, this will keep the comments that were present in the file.
+As an alternative, you could store a reference to a :doc:`serializable config instance <serialization>` that holds the
+entire configuration of your plugin.
 
 .. note::
 

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -146,7 +146,7 @@ even generic types can conveniently be written and read.
 	The SpongeAPI provides a :javadoc:`TypeTokens {class}` with many pre-defined type tokens that you can use.
 	If plugin developers need many different or complex ``TypeToken``\s, or use them frequently, it is recommended
 	to create a similar class for themselves to improve code readability. (It is not guaraneteed that all of those
-	entries have registed ``TypeSerializer``\s.)
+	entries have registered ``TypeSerializer``\s.)
 
 The following types can be (de-)serialized using those methods:
 

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -145,7 +145,7 @@ even generic types can conveniently be written and read.
 
 	The SpongeAPI provides a :javadoc:`TypeTokens {class}` with many pre-defined type tokens that you can use.
 	If plugin developers need many different or complex ``TypeToken``\s, or use them frequently, it is recommended
-	to create a similar class for themselves to improve code readability. (It is not guaraneteed that all of those
+	to create a similar class for themselves to improve code readability. (It is not guaranteed that all of those
 	entries have registered ``TypeSerializer``\s.)
 
 The following types can be (de-)serialized using those methods:

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -29,7 +29,6 @@ entire configuration of your plugin.
     addition to normal ``ConfigurationNode`` behavior is able to retain a comment that will persist on the saved config
     file.
 
-
 Navigating Nodes
 ================
 
@@ -97,7 +96,6 @@ and can be done as follows:
 
     rootNode.getNode("modules", "blockCheats", "enabled").setValue(false);
 
-
 .. warning::
 
     Anything other than basic value types cannot be handled by those basic functions, and must instead be read and
@@ -161,7 +159,6 @@ even generic types can conveniently be written and read.
 You can find a non-exhaustive list of supported types, and ways to add support for new types on the
 :doc:`the config serialization page <serialization>`.
 
-
 Defaults
 ~~~~~~~~
 
@@ -183,7 +180,7 @@ that is the value specified on the config. Unless we specify ``true`` as the def
 
 .. code-block:: java
 
-    boolean shouldEnable = rootNode.getNode("modules", "blockCheats", "enabled") .getBoolean(true);
+    boolean shouldEnable = rootNode.getNode("modules", "blockCheats", "enabled").getBoolean(true);
 
 Similarly, you can specify defaults on any value you get from the config, thus avoiding ``null`` returns or
 ``ObjectMappingException`` caused by the absence of the whole value. It also works on the deserializing ``getValue()``

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -17,8 +17,8 @@ Configuration Nodes
 
 In memory, the configuration is represented using :javadoc:`ConfigurationNode`\ s. A ``ConfigurationNode`` either holds
 a value (like a number, a string or a list) or has child nodes, a tree-like configuration structure. When using a
-:javadoc:`ConfigurationLoader` to load or create new configurations, it will return the **root node**. It is
-recommended that you always keep a reference to that root node stored somewhere, to prevent loading the configuration
+:javadoc:`ConfigurationLoader` to load or create new configurations, it will return the **root node**. We
+recommend that you always keep a reference to that root node stored somewhere, to prevent loading the configuration
 every time you need to access it. As a side effect, this will keep the comments that were present in the file.
 As an alternative, you could store a reference to a :doc:`serializable config instance <serialization>` that holds the
 entire configuration of your plugin.
@@ -154,8 +154,8 @@ even generic types can conveniently be written and read.
 .. tip::
 
     The SpongeAPI provides a :javadoc:`TypeTokens {class}` with many pre-defined type tokens that you can use.
-    If plugin developers need many different or complex ``TypeToken``\s, or use them frequently, it is recommended
-    to create a similar class for themselves to improve code readability. (Beware, it is not guaranteed that all of
+    If plugin developers need many different or complex ``TypeToken``\s, or use them frequently, we recommend
+    creating a similar class for themselves to improve code readability. (Beware, it is not guaranteed that all of
     those entries have registered ``TypeSerializer``\s).
 
 You can find a non-exhaustive list of supported types, and ways to add support for new types on the

--- a/source/plugin/configuration/nodes.rst
+++ b/source/plugin/configuration/nodes.rst
@@ -140,10 +140,11 @@ method with a ``TypeToken`` and the object you want to serialize.
     can be found.
 
 For simple classes like ``UUID``, you can just create a ``TypeToken`` using the static :javadoc:`TypeToken#of(Class)`
-method. But when the class you want to use has type parameters of its own (like ``Map<String,UUID>``) the syntax gets a
-little more complicated. In most cases you will know exactly what the type parameters will be at compile time, so
-you can just create the ``TypeToken`` as an anonymous class: ``new TypeToken<Map<String,UUID>>() {}``. That way,
-even generic types can conveniently be written and read.
+method. However, ``UUID``\s and some other types already have a constant for it, such as
+:javadoc:`TypeTokens#UUID_TOKEN`, which you should use instead. If the class you want to use has type parameters (like
+``Map<String,UUID>``) and no constant yet exists for it, the syntax gets a bit more complicated. In most cases you will
+know exactly what the type parameters will be at compile time, so you can just create the ``TypeToken`` as an anonymous
+class: ``new TypeToken<Map<String,UUID>>() {}``. That way, even generic types can conveniently be written and read.
 
 .. seealso::
     For more information about ``TypeToken``\s, refer to the `guava documentation

--- a/source/plugin/configuration/serialization.rst
+++ b/source/plugin/configuration/serialization.rst
@@ -3,6 +3,14 @@ Serializing Objects
 ===================
 
 .. javadoc-import::
+
+    java.util.List
+    java.util.Map
+    java.util.Set
+    java.util.UUID
+    java.net.URL
+    java.net.URI
+    java.util.regex.Pattern
     ninja.leaping.configurate.ConfigurationOptions
     ninja.leaping.configurate.objectmapping.GuiceObjectMapperFactory
     ninja.leaping.configurate.objectmapping.ObjectMapper
@@ -11,11 +19,27 @@ Serializing Objects
     ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable
     ninja.leaping.configurate.objectmapping.serialize.TypeSerializer
     ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection
+    org.spongepowered.api.text.Text
+    org.spongepowered.api.text.TextTemplate
+    org.spongepowered.api.text.format.TextFormat
 
 The Configurate library also provides the means to tweak automatic serialization and deserialization of objects.
-Per default, a set of data types can be (de)serialized: among others Strings, ints, doubles, UUIDs, Lists
-(of serializable values) and Maps (where both keys and values are serializable). But if you want to write your
-custom data structures to a config file, this will not be enough.
+Per default, a set of data types can be (de)serialized: 
+
+* ``String``\s, the most commonly used primitive types and their wrappers
+* :javadoc:`List`\s and :javadoc:`Set`\s of serializable values (not including specific implementations)
+* :javadoc:`Map`\s where both keys and values are serializable (not including specific implementations)
+* The types :javadoc:`UUID`, :javadoc:`URL`, :javadoc:`URI` and :javadoc:`Pattern {(regex) Pattern}`
+* Any enum or :doc:`CatalogType </plugin/data/catalog-types>`
+* The types :javadoc:`Text`, :javadoc:`TextFormat` and :javadoc:`TextTemplate` (See also
+  :doc:`here </plugin/text/index>`)
+
+.. note::
+
+    If you need special constraints or rules for your serialization (such as sorting the elements in a ``Set``),
+    then you should consider using your own ``TypeSerializer`` implementations.
+
+But if you want to write your custom data structures to a config file, this will not be enough.
 
 Imagine a data structure tracking how many diamonds a player has mined. It might look a little like this:
 

--- a/source/plugin/configuration/serialization.rst
+++ b/source/plugin/configuration/serialization.rst
@@ -164,6 +164,11 @@ The ``@ConfigSerializable`` annotation eliminates the need for any registration 
 just generate an :javadoc:`ObjectMapper` for the class. The only limitation is that Configurate needs an empty
 constructor to instantiate a new object before filling in the annotated fields.
 
+.. note::
+
+    You can also have fields that are not are not annotated with ``@Setting`` in your ``@ConfigSerializable`` classes.
+    These fields won't be persisted to config files and can be used to store temporary references for your plugin.
+
 Using Default Values in ConfigSerializable Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/plugin/configuration/serialization.rst
+++ b/source/plugin/configuration/serialization.rst
@@ -88,6 +88,11 @@ This ``TypeSerializer`` must then be registered with Configurate. This can be do
 the default :javadoc:`TypeSerializerCollection` or locally, by specifying it in the :javadoc:`ConfigurationOptions`
 when loading your config.
 
+.. note::
+
+    ``ConfigurationOptions`` are immutable. Every time you try to modify the original instance a new instance is
+    created; so you either have to use the (chained) result directly or update your variable accordingly.
+
 **Code Example: Registering a TypeSerializer globally**
 
 .. code-block:: java

--- a/source/plugin/configuration/serialization.rst
+++ b/source/plugin/configuration/serialization.rst
@@ -172,9 +172,9 @@ constructor to instantiate a new object before filling in the annotated fields.
 Using Default Values in ConfigSerializable Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It is also possible to use default values inside of ``@ConfigSerializable`` types, you just have to use Java's field
-initializers to set some default values; as long as the entry is not present in the config file the value won't be
-overwritten.
+It is also possible to use default values inside of ``@ConfigSerializable`` types. You just have to use Java's field
+initializers (or getters) to set some default values. As long as the entry is not present in the config file the value
+won't be overwritten.
 
 .. code-block:: java
 
@@ -221,14 +221,14 @@ configuration. Using such a class has the following benefits:
 
     In this case ``Configuration.generateDefault()`` is called when the config file is missing or empty.
     If you still want to load the shipped default config asset you can load it inside of that method.
-    ``Configuration.generateErrorDefault()`` is called when there was an error reading or parsing the config.
-    It is not necessary to use separate methods for those cases, you can also use the no-arg constructor in those cases,
+    ``Configuration.generateErrorDefault()`` is called when there is an error reading or parsing the config.
+    It is not necessary to use separate methods for those cases; you can also use the no-arg constructor,
     or use an entirely custom solution.
 
 Example: Saving a ConfigSerializable Config
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Saving a ``@ConfigSerializable`` config is also very simple as shown by the following example:
+Saving a ``@ConfigSerializable`` config is also very simple, as shown by the following example:
 
 .. code-block:: java
 

--- a/source/plugin/configuration/serialization.rst
+++ b/source/plugin/configuration/serialization.rst
@@ -19,8 +19,6 @@ Serializing Objects
     ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable
     ninja.leaping.configurate.objectmapping.serialize.TypeSerializer
     ninja.leaping.configurate.objectmapping.serialize.TypeSerializerCollection
-    org.spongepowered.api.text.Text
-    org.spongepowered.api.text.TextTemplate
     org.spongepowered.api.text.format.TextFormat
 
 The Configurate library also provides the means to tweak automatic serialization and deserialization of objects.
@@ -31,8 +29,8 @@ Per default, a set of data types can be (de)serialized:
 * :javadoc:`Map`\s where both keys and values are serializable (not including specific implementations)
 * The types :javadoc:`UUID`, :javadoc:`URL`, :javadoc:`URI` and :javadoc:`Pattern {(regex) Pattern}`
 * Any enum or :doc:`CatalogType </plugin/data/catalog-types>`
-* The types :javadoc:`Text`, :javadoc:`TextFormat` and :javadoc:`TextTemplate` (See also
-  :doc:`here </plugin/text/index>`)
+* The types :doc:`Text </plugin/text/index>`, :javadoc:`TextFormat` and
+  :doc:`TextTemplate </plugin/text/templates>` (See also :doc:`here </plugin/text/representations/index>`)
 
 .. note::
 


### PR DESCRIPTION
Fixes #735
Fixes #553 

**Tasks**

* [x] Mention [`TypeTokens`](https://github.com/SpongePowered/SpongeAPI/blob/stable-7/src/main/java/org/spongepowered/api/util/TypeTokens.java) which contains already existing type tokens and mention that the user should possibly should use a similar approach if he has multiple type tokens itself.
* [x] Find out which types have serializers registered by default (any of the above?)
  * http://configurate.aoeu.xyz/wiki/Object-Mapper.html
  * ``Set``s? is the order retained? sorted?
  * [x] Move the supported types list to a single place. (serialization)
* [x] Which ~text~ serialization format does SpongeAPI use in Configurate by default?
  * Hocon is mentioned multiple times
  * Maybe mention it on the loaders page again
  * Stronger links between config and [Text Serializers](https://docs.spongepowered.org/stable/en/plugin/text/representations/index.html)
* [x] Which should you use for your plugin?
  * Sponge recommends hocon (Mentioned on the index page)
  * Maybe mention it on the loaders page again
* [x] How do you override this choice in your plugin for your configurations, or should you use string's and handle serialization yourself?
  * [x] YAML is mentioned, but Gson is not.
  * Needs an example (loaders page)
* [x] Add a full example of loading and saving a `@ConfigSerializable` instance to [Using Objectmappers](https://docs.spongepowered.org/stable/en/plugin/configuration/serialization.html#using-objectmappers).
  * [x] Mention the implications of not using `@Setting` on a field
  * How to use default values
  * What happens if new values are added/are missing in the config file
* [x] Expand the example regarding the usage of defaults.
  * How do you actually merge the configs
  * How are/should partial default defaults handled
* [x] Explain when the config should be saved (for the first time)

----------------------------

## TBD

* [ ] Mention recommended way to serialize `Text`s.
