### PR TITLE
Updates for new Versioning Policy

### DIFF
--- a/source/contributing/versioning.rst
+++ b/source/contributing/versioning.rst
@@ -14,7 +14,7 @@ The Bleeding Branch
 
 The core of our repositories is the ``bleeding`` branch. Almost all changes will be added to ``bleeding``, including
 new features, changes, and bugfixes. The version of ``bleeding`` will always be the next major release version 
-appended with ``-SNAPSHOT`` (e.g. ``8.0-SNAPSHOT``) to denote that it is not yet a final build and subject to change.
+appended with ``-SNAPSHOT`` (e.g. ``7.0.0-SNAPSHOT``) to denote that it is not yet a final build and subject to change.
 
 The primary reason for having the ``bleeding`` branch is to have a testing ground for changes. Even experienced
 members of the Sponge team can accidentally cause a build to fail or miss a bug. The ``bleeding`` branch will be
@@ -29,7 +29,7 @@ will be no breakages to API, only non-breaking additions. There is a branch name
 contains the latest API/implementation for that release including any minor or patch releases.
 
 When the time comes to release a major version, a new ``stable-x`` branch will be created from ``bleeding``, where
-``x`` is the new major version - for example, ``stable-8``. ``bleeding`` will be appropriately updated to be the next
+``x`` is the new major version - for example, ``stable-7``. ``bleeding`` will be appropriately updated to be the next
 major release as described above.
 
 Changes that have been in ``bleeding`` for a while, which have no known bugs, and that can be applied to a previous

--- a/source/contributing/versioning.rst
+++ b/source/contributing/versioning.rst
@@ -1,26 +1,9 @@
-==============================================
-Versioning System and Repository Branch Layout
-==============================================
+========================
+Repository Branch Layout
+========================
 
-With the release for beta we've moved SpongeAPI versioning to semantic versioning (see https://semver.org/).
-This change means that every time that we make a release we have to increment the version according to the rules
-of SemVer.
-
-SemVer
-======
-
-SemVer uses the scheme ``X.Y.Z``, where ``X`` is a *major* version, ``Y`` is a *minor* one and ``Z`` finally is a
-*patch* version.
-A release containing changes which are not backwards-compatible must be one *major* version ahead of the previous
-release. If there are only new features that are still backwards compatible, then the new release will be one *minor*
-version ahead of the previous release, and if the release strictly contains bugfixes then only the *patch* version will
-be incremented.
-
-This means that for example ``3.2.0`` is fully compatible to ``3.0.0`` while ``4.0.0`` isn't binary compatible to
-``3.0.0``. ``3.1.0`` and ``3.1.2`` are fully interchangeable besides the bugs that were fixed.
-
-The layout of our branches (described below) is designed to assist this process by allowing us to make minor releases
-without a breaking change forcing us to make it a major release. This branch layout applies to SpongeAPI,
+The layout of our branches is designed to assist :ref:`semantic versioning <sem-ver>` by allowing us to make minor 
+releases without a breaking change forcing us to make it a major release. This branch layout applies to SpongeAPI, 
 SpongeCommon, SpongeForge, and SpongeVanilla repositories but not to the SpongeDocs.
 
 SpongeAPI, SpongeCommon, SpongeForge and SpongeVanilla
@@ -30,8 +13,8 @@ The Bleeding Branch
 ~~~~~~~~~~~~~~~~~~~
 
 The core of our repositories is the ``bleeding`` branch. Almost all changes will be added to ``bleeding``, including
-new features, changes, and bugfixes. The version of ``bleeding`` will always be the next major release version
-appended with ``-SNAPSHOT`` (e.g. ``6.0.0-SNAPSHOT``) to denote that it is not yet a final build and subject to change.
+new features, changes, and bugfixes. The version of ``bleeding`` will always be the next major release version 
+appended with ``-SNAPSHOT`` (e.g. ``8.0-SNAPSHOT``) to denote that it is not yet a final build and subject to change.
 
 The primary reason for having the ``bleeding`` branch is to have a testing ground for changes. Even experienced
 members of the Sponge team can accidentally cause a build to fail or miss a bug. The ``bleeding`` branch will be
@@ -46,7 +29,7 @@ will be no breakages to API, only non-breaking additions. There is a branch name
 contains the latest API/implementation for that release including any minor or patch releases.
 
 When the time comes to release a major version, a new ``stable-x`` branch will be created from ``bleeding``, where
-``x`` is the new major version - for example, ``stable-5``. ``bleeding`` will be appropriately updated to be the next
+``x`` is the new major version - for example, ``stable-8``. ``bleeding`` will be appropriately updated to be the next
 major release as described above.
 
 Changes that have been in ``bleeding`` for a while, which have no known bugs, and that can be applied to a previous

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,8 +8,8 @@ Introduction
 Welcome to SpongeDocs, the official documentation for the open-source `Sponge <https://www.spongepowered.org>`__ project.
 
 SpongeAPI is your all new plugin API for Minecraft: Java Edition. You can run it on a plain vanilla server (as
-SpongeVanilla) or on your fully modded MinecraftForge server (as SpongeForge). Grab your copy
-`here <https://www.spongepowered.org/downloads>`_.
+SpongeVanilla) or on your fully modded MinecraftForge server (as SpongeForge). Check out our :doc:`versions/index` to 
+understand selecting a file and grab your copy from our `downloads page <https://www.spongepowered.org/downloads>`_.
 
 Not sure what you're looking for? Try our :doc:`about/index` section, which contains a short :doc:`about/introduction`,
 our :doc:`about/faq` and an article about :doc:`about/structure`.
@@ -34,6 +34,17 @@ or visit their repositories on GitHub:
 
 Contents
 ========
+
+Versioning Policy
+~~~~~~~~~~~~~~~~~
+
+This section describes how Sponge manages versions.
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    versions/index
 
 Creating a Server
 ~~~~~~~~~~~~~~~~~

--- a/source/index.rst
+++ b/source/index.rst
@@ -35,17 +35,6 @@ or visit their repositories on GitHub:
 Contents
 ========
 
-Versioning Policy
-~~~~~~~~~~~~~~~~~
-
-This section describes how Sponge manages versions.
-
-.. toctree::
-    :maxdepth: 2
-    :titlesonly:
-
-    versions/index
-
 Creating a Server
 ~~~~~~~~~~~~~~~~~
 
@@ -56,6 +45,17 @@ This section is for users who have a Sponge server or are interested in creating
     :titlesonly:
 
     server/index
+
+Versioning Policy
+~~~~~~~~~~~~~~~~~
+
+This section describes how Sponge manages versions.
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    versions/index
 
 Preparing for Development
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/plugin/api-versions.rst
+++ b/source/plugin/api-versions.rst
@@ -40,7 +40,7 @@ Getting the API Version from Implementations
 Getting it from the Jar
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-See :doc:`../../versions/versioning`.
+See :doc:`/versions/versioning`.
 
 .. _associated-minecraft-version:
 

--- a/source/plugin/api-versions.rst
+++ b/source/plugin/api-versions.rst
@@ -10,10 +10,13 @@ This page explains which API versions exist, and to which Minecraft version thei
 | *8.0.0*     | TBA          | TBA            | * *SpongeForge (1.13.x)*                  |
 |             |              |                | * *SpongeVanilla (1.13.x)*                |
 +-------------+--------------+----------------+-------------------------------------------+
+| 7.2.0       | TBA          | TBA            | * SpongeForge (1.12.2)                    |
+|             |              |                | * SpongeVanilla (1.12.2)                  |
++-------------+--------------+----------------+-------------------------------------------+
 | 7.1.0       | Sep 6, 2018  | TBA            | * SpongeForge (1.12.2)                    |
 |             |              |                | * SpongeVanilla (1.12.2)                  |
 +-------------+--------------+----------------+-------------------------------------------+
-| 7.0.0       | Jan 1, 2018  | TBA            | * SpongeForge (1.12.2)                    |
+| 7.0.0       | Jan 1, 2018  | Sep 5, 2018    | * SpongeForge (1.12.2)                    |
 |             |              |                | * SpongeVanilla (1.12.2)                  |
 +-------------+--------------+----------------+-------------------------------------------+
 | 6.0.0       | May 2, 2017  | Dec 31, 2017   | * SpongeForge (1.11.2)                    |
@@ -37,41 +40,7 @@ Getting the API Version from Implementations
 Getting it from the Jar
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-* For `SpongeForge <https://www.spongepowered.org/downloads/spongeforge/>`__: 
-
-  **Example:** ``spongeforge-1.12.2-2705-7.1.0-BETA-3361.jar``
-  
-  => API-Version ``7.1.0``
-  
-  See also :ref:`sponge-forge-file-name`.
-
-* For `SpongeVanilla <https://www.spongepowered.org/downloads/spongevanilla/>`__:
-
-  **Example:** ``spongevanilla-1.12.2-7.1.0-BETA-59.jar``
-  
-  => API-Version ``7.1.0``
-
-.. note::
-
-    The version string in SpongeForge & SpongeVanilla is currently flawed, it currently has a minor version number
-    referring to **unreleased** API versions, and is planned to be fixed going forward in some future update.
-
-    As we follow SemVer, changes in 7.1.0 should be backwards compatible with 7.0.0, as such, we often ship
-    SpongeForge & SpongeVanilla with **preview** implementations of the upcoming API release.
-
-    The API contained within the preview API builds can and will change before it's released, so for plugin
-    compatibility sake, it's best to use plugins for the latest stable released API, and not the API preview versions.
-
-    As such, if the API version number in the filename points to 7.2.0 but 7.2.0 is not yet announced to be released,
-    you should use plugins built against 7.1.0 unless specifically testing new functionality as asked by plugin devs, or
-    you are willing to put up with small breakages occasionally for the sake of new features.
-
-    This **WILL** be fixed in the near future. When this happens the Version number of SpongeForge & SpongeVanilla will
-    no longer reference unreleased SpongeAPI minor versions, but will still ship previews of the next minor API for
-    testing purposes.
-
-    Major API version bumps will be reserved for the experimental / bleeding builds, and will be very explicit as their
-    major version number will be different.
+See :doc:`../../versions/versioning`.
 
 .. _associated-minecraft-version:
 

--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -18,7 +18,7 @@ SpongeCommon
 
 - **Group ID**: ``org.spongepowered``
 - **Artifact ID**: ``spongecommon``
-- **Version**: Same as SpongeAPI
+- **Version**: Same as SpongeAPI + current recommended version (see :doc:`../../../versions/versioning` for details)
 - **Classifier**: ``dev``
 
 Example Using Gradle
@@ -27,7 +27,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongecommon:7.1.0:dev'
+        compile 'org.spongepowered:spongecommon:8.1.0:dev'
     }
 
 SpongeVanilla
@@ -46,7 +46,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongevanilla:1.12.2-7.1.0-BETA-116:dev'
+        compile 'org.spongepowered:spongevanilla:1.13.2-8.1.0-RC116:dev'
     }
 
 SpongeForge
@@ -65,5 +65,5 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongeforge:1.12.2-2705-7.1.0-BETA-3442:dev'
+        compile 'org.spongepowered:spongeforge:1.13.2-2705-8.1.0-RC3442:dev'
     }

--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -46,7 +46,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongevanilla:1.12.2-7.1.0-RC116:dev'
+        compile 'org.spongepowered:spongevanilla:1.12.2-7.1.1-RC123:dev'
     }
 
 SpongeForge
@@ -65,5 +65,5 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongeforge:1.12.2-2705-7.1.0-RC3442:dev'
+        compile 'org.spongepowered:spongeforge:1.12.2-2768-7.1.1-RC3484:dev'
     }

--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -27,7 +27,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongecommon:8.1.0:dev'
+        compile 'org.spongepowered:spongecommon:7.1.0:dev'
     }
 
 SpongeVanilla

--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -18,7 +18,7 @@ SpongeCommon
 
 - **Group ID**: ``org.spongepowered``
 - **Artifact ID**: ``spongecommon``
-- **Version**: Same as SpongeAPI + current recommended version (see :doc:`../../../versions/versioning` for details)
+- **Version**: Same as SpongeAPI + current recommended version (see :doc:`/versions/versioning` for details)
 - **Classifier**: ``dev``
 
 Example Using Gradle

--- a/source/plugin/internals/implementation.rst
+++ b/source/plugin/internals/implementation.rst
@@ -46,7 +46,7 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongevanilla:1.13.2-8.1.0-RC116:dev'
+        compile 'org.spongepowered:spongevanilla:1.12.2-7.1.0-RC116:dev'
     }
 
 SpongeForge
@@ -65,5 +65,5 @@ Example Using Gradle
 .. code-block:: groovy
 
     dependencies {
-        compile 'org.spongepowered:spongeforge:1.13.2-2705-8.1.0-RC3442:dev'
+        compile 'org.spongepowered:spongeforge:1.12.2-2705-7.1.0-RC3442:dev'
     }

--- a/source/server/getting-started/implementations/spongeforge.rst
+++ b/source/server/getting-started/implementations/spongeforge.rst
@@ -75,8 +75,8 @@ Installing SpongeForge
 .. note::
 
   When using the Mojang installer, Mojang makes use of their own Java version and not the one you installed on your
-  system. The installer currently ships with Java ``1.8.0_25`` for Windows and ``1.8.0_60`` for macOS. Note that Sponge
-  requires **at least** ``1.8.0_20`` or above to run properly but it is recommended to use the latest Java 8 version.
+  system. The installer currently ships with Java ``1.8.0_74``. Note that Sponge requires **at least** ``1.8.0_20`` or 
+  above to run properly but it is recommended to use the latest Java 8 version.
 
 Single Player / In-Game LAN Servers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/getting-started/implementations/spongeforge.rst
+++ b/source/server/getting-started/implementations/spongeforge.rst
@@ -10,7 +10,7 @@ Users who do not want to use Minecraft Forge can consider :doc:`SpongeVanilla <s
 Download
 ========
 
-Review our :doc:`../../../../versions/versioning` and grab your copy of `SpongeForge here <https://www.spongepowered.org/downloads>`_.
+Review our :doc:`/versions/versioning` and grab your copy of `SpongeForge here <https://www.spongepowered.org/downloads>`_.
 
 Installing SpongeForge
 ======================

--- a/source/server/getting-started/implementations/spongeforge.rst
+++ b/source/server/getting-started/implementations/spongeforge.rst
@@ -10,59 +10,7 @@ Users who do not want to use Minecraft Forge can consider :doc:`SpongeVanilla <s
 Download
 ========
 
-Grab your copy of `SpongeForge here <https://www.spongepowered.org/downloads>`_.
-
-.. _sponge-forge-file-name:
-
-Reading the Download Filename
-=============================
-
-When you download SpongeForge, the name of the file will provide some important version information. It includes a
-Forge build number which this version of SpongeForge is compatible with. Other builds, even ones differing by only a
-few build numbers are not officially supported.
-
-However, SpongeForge usually updates to a new Forge build fairly soon after it's released, so you needn't
-worry about always having to run an outdated Forge version in order to use SpongeForge.
-
-
-The format of the filename is ``spongeforge-<MCVersion>-<ForgeBuildId>-<SpongeAPIVersion>-BETA-<SpongeBuildId>.jar``
-
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``MCVersion``        | The Minecraft version. Only clients compatible with this version can connect.                 |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``ForgeBuildId``     | Preferably your server should run this exact version of Forge (which can be identified in the |
-|                      | last part of Forge's version string).                                                         |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``SpongeAPIVersion`` | The version of SpongeAPI implemented by this file. This is what Sponge plugins depend on.     |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``SpongeBuildId``    | The build number of Sponge. This is what you should supply when reporting bugs or seeking     |
-|                      | support.                                                                                      |
-+----------------------+-----------------------------------------------------------------------------------------------+
-
-Example
-~~~~~~~
-
-SpongeForge Jar files will always follow this naming scheme, to allow you to easily identify compatibility.
-
-For example, the file name ``spongeforge-1.12.2-2705-7.1.0-BETA-3442.jar`` is compatible with Minecraft version
-``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), provides SpongeAPI ``7.1.0`` and was build number
-``3442`` of SpongeForge.
-
-.. note::
-
-    Normal Forge mods can usually run on any build of Forge for a given Minecraft version (e.g. 1.8.0) without any
-    problem. However, SpongeForge needs to access, among other things, internal parts of Forge, which most mods
-    shouldn’t be touching, let alone modifying as Sponge does. Since Forge is free to change their internal code
-    whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
-    use more recent versions of Forge, than the one used for SpongeForge, but we can't always guarantee compatibility.
-
-.. warning::
-
-    When investigating crash issues, you can freely try newer versions of Forge than listed on the SpongeForge Jar.
-    However, it is recommended to also check with the matching version, to make sure your issue is not related to a
-    version mismatch.
-    Even though there will be no guarantee of compatibility, please report any breakage to the issue tracker, so that
-    SpongeForge can be updated.
+Review our :doc:`../../../../versions/versioning` and grab your copy of `SpongeForge here <https://www.spongepowered.org/downloads>`_.
 
 Installing SpongeForge
 ======================

--- a/source/server/getting-started/implementations/spongevanilla.rst
+++ b/source/server/getting-started/implementations/spongevanilla.rst
@@ -17,7 +17,8 @@ do not want to run a Forge server. Originally started as an independent project 
 Download
 ========
 
-Grab your copy of `SpongeVanilla here <https://www.spongepowered.org/downloads>`_.
+Review our :doc:`/versions/versioning` and grab your copy of `SpongeVanilla here 
+<https://www.spongepowered.org/downloads>`_.
 
 Installing SpongeVanilla
 ========================

--- a/source/server/getting-started/implementations/spongevanilla.rst
+++ b/source/server/getting-started/implementations/spongevanilla.rst
@@ -31,8 +31,8 @@ Installing SpongeVanilla
 .. note::
 
   When using the Mojang installer, Mojang makes use of their own Java version and not the one you installed on your
-  system. The installer currently ships with Java ``1.8.0_25`` for Windows and ``1.8.0_60`` for macOS. Note that Sponge
-  requires **at least** ``1.8.0_20`` or above to run properly but it is recommended to use the latest Java 8 version.
+  system. The installer currently ships with Java ``1.8.0_74``. Note that Sponge requires **at least** ``1.8.0_20`` or 
+  above to run properly but it is recommended to use the latest Java 8 version.
 
 SpongeVanilla only works as a dedicated server.
 

--- a/source/server/spongineer/debugging.rst
+++ b/source/server/spongineer/debugging.rst
@@ -23,7 +23,7 @@ Is the recommended Forge version installed?
 Usually SpongeForge will run on older or newer Forge builds than the recommended build.
 However, it is strongly advised to run the recommended build only.
 If you encounter a crash and your versions are mismatching, match them first and try again.
-If you're unsure which Forge build you need, take a look at :doc:`/server/getting-started/implementations/spongeforge`
+If you're unsure which Forge build you need, take a look at the **SpongeForge** section of :doc:`../../versions/filenames`.
 
 Are there any other coremods installed?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,7 +95,7 @@ Mismatched SpongeForge and Forge
 
 This is a common crash when you try to run SpongeForge on the wrong Forge build. Note that the target/Mixin can vary.
 Always match Forge against SpongeForge! If you're unsure which version of Forge is required and you already got your
-SpongeForge build, take a look at: :doc:`../getting-started/implementations/spongeforge/`
+SpongeForge build, take a look at the **SpongeForge** section of :doc:`../../versions/filenames`. 
 
 Other common errors
 ~~~~~~~~~~~~~~~~~~~

--- a/source/server/spongineer/debugging.rst
+++ b/source/server/spongineer/debugging.rst
@@ -23,7 +23,7 @@ Is the recommended Forge version installed?
 Usually SpongeForge will run on older or newer Forge builds than the recommended build.
 However, it is strongly advised to run the recommended build only.
 If you encounter a crash and your versions are mismatching, match them first and try again.
-If you're unsure which Forge build you need, take a look at the **SpongeForge** section of :doc:`../../versions/filenames`.
+If you're unsure which Forge build you need, take a look at the **SpongeForge** section of :doc:`/versions/filenames`.
 
 Are there any other coremods installed?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,7 +95,7 @@ Mismatched SpongeForge and Forge
 
 This is a common crash when you try to run SpongeForge on the wrong Forge build. Note that the target/Mixin can vary.
 Always match Forge against SpongeForge! If you're unsure which version of Forge is required and you already got your
-SpongeForge build, take a look at the **SpongeForge** section of :doc:`../../versions/filenames`. 
+SpongeForge build, take a look at the **SpongeForge** section of :doc:`/versions/filenames`. 
 
 Other common errors
 ~~~~~~~~~~~~~~~~~~~

--- a/source/server/spongineer/logs.rst
+++ b/source/server/spongineer/logs.rst
@@ -182,7 +182,7 @@ The example log indicates that we're running:
  [main/INFO] [FML]: Loading tweaker org.spongepowered.asm.launch.MixinTweaker from spongeforge-1.12.2-2705-7.1.0-BETA-3136.jar
 
 This indicates that SpongeForge 3136 was found and loaded by Forge. For further help regarding the SpongeForge
-naming scheme, have a look here: :doc:`../getting-started/implementations/spongeforge/`.
+naming scheme, have a look at :doc:`../../versions/filenames`.
 
 latest.log
 ~~~~~~~~~~

--- a/source/server/spongineer/logs.rst
+++ b/source/server/spongineer/logs.rst
@@ -182,7 +182,7 @@ The example log indicates that we're running:
  [main/INFO] [FML]: Loading tweaker org.spongepowered.asm.launch.MixinTweaker from spongeforge-1.12.2-2705-7.1.0-BETA-3136.jar
 
 This indicates that SpongeForge 3136 was found and loaded by Forge. For further help regarding the SpongeForge
-naming scheme, have a look at :doc:`../../versions/filenames`.
+naming scheme, have a look at :doc:`/versions/filenames`.
 
 latest.log
 ~~~~~~~~~~

--- a/source/versions/filenames.rst
+++ b/source/versions/filenames.rst
@@ -2,6 +2,11 @@
 Reading the Download Filename
 =============================
 
+.. note::
+
+    Our versioning policy was updated in October 2018. **Beginning with** SpongeAPI 7.1, the following information 
+    applies. See :doc:`legacy-versions` for information on older versions.
+
 When you download files, the name of the file will provide some important version information. The following sections 
 describe the information provided.
 
@@ -10,25 +15,14 @@ describe the information provided.
 SpongeForge
 ===========
 
-.. note::
-
-    Our versioning policy was updated in October 2018. **Beginning with** SpongeAPI 8.0, the following information 
-    applies. See :doc:`legacy-versions` for information on older versions.
-
-When you download SpongeForge, the name of the file includes a Forge build number which this version of SpongeForge is 
-built with and guaranteed to be compatible. We do not support newer versions of Forge; however, we try to get an update 
-out when a Forge release breaks SpongeForge. You can try the Forge version needed as it will work fine most of the 
-time. If it doesn't, we hope to release a SpongeForge compatible with that Forge version soon. 
-
-The format of the filename is:
+The format of the SpongeForge download filename is:
 
 ``spongeforge-<MCVersion>-<ForgeBuild>-<APIMajor>.<LatestAPIMinorRelease>.<RecommendedVersion(-RC<BuildNumber>)>.jar``
 
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``MCVersion``        | The Minecraft version. Only clients compatible with this version can connect.                 |
 +----------------------+-----------------------------------------------------------------------------------------------+
-| ``ForgeBuild``       | Preferably your server should run this exact version of Forge (which can be identified in the |
-|                      | last part of Forge's version string).                                                         |
+| ``ForgeBuild``       | The Forge build that SpongeForge is built against and is guaranteed to be compatible          |
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``APIMajor``         | The major version of SpongeAPI implemented by this file (the ``X`` in                         |
 |                      | :ref:`semantic versioning<sem-ver>`).                                                         |
@@ -43,8 +37,20 @@ The format of the filename is:
 | ``<BuildNumber>``    | present, the ``RecommendedVersion`` has **not** been released yet.                            |
 +----------------------+-----------------------------------------------------------------------------------------------+
 
+The Forge Build in the filename specifies the version of Forge this version of SpongeForge used during development and 
+testing. The two versions are guaranteed to work without any issues. We **tend** to use the latest *Recommended Build* 
+of Forge for this purpose.
+
+.. note::
+
+    Normal Forge mods can usually run on any build of Forge for a given Minecraft version (e.g. 1.12.2) without any 
+    problem. However, SpongeForge needs to access, among other things, internal parts of Forge, which most mods
+    shouldn’t be touching, let alone modifying as Sponge does. Since Forge is free to change their internal code
+    whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
+    use more recent versions of Forge than the one used for SpongeForge, but we can't always guarantee compatibility.
+
 Examples
-~~~~~~~~
+--------
 
 SpongeForge Jar files will always follow this naming scheme to allow you to easily identify compatibility.
 
@@ -56,22 +62,6 @@ Another example is the file name ``spongeforge-1.12.2-2705-7.1.5-RC3449.jar``. T
 version ``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), guarantees compatibility with SpongeAPI 
 ``7.1.0``, is not a recommended version, and is build number ``3449`` in development, which will be the ``5`` th 
 release of SpongeForge once this version is released. 
-
-.. note::
-
-    Normal Forge mods can usually run on any build of Forge for a given Minecraft version (e.g. 1.8.0) without any
-    problem. However, SpongeForge needs to access, among other things, internal parts of Forge, which most mods
-    shouldn’t be touching, let alone modifying as Sponge does. Since Forge is free to change their internal code
-    whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
-    use more recent versions of Forge, than the one used for SpongeForge, but we can't always guarantee compatibility.
-
-.. warning::
-
-    When investigating crash issues, you can freely try newer versions of Forge than listed on the SpongeForge Jar.
-    However, it is recommended to also check with the matching version, to make sure your issue is not related to a
-    version mismatch.
-    Even though there will be no guarantee of compatibility, please report any breakage to the issue tracker, so that
-    SpongeForge can be updated.
 
 SpongeVanilla
 =============
@@ -92,6 +82,10 @@ The format of the filename is:
 
 ``spongeapi-<APIMajor>.<LatestAPIMinorRelease>.0-<Date>.<Time>-<BuildNumber>-shaded.jar``
 
+**OR**
+
+``spongeapi-<APIMajor>.<LatestAPIMinorRelease>.0-SNAPSHOT.jar``
+
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``APIMajor``         | The major version of SpongeAPI implemented by this file (the ``X`` in                         |
 |                      | :ref:`semantic versioning<sem-ver>`).                                                         |
@@ -108,8 +102,15 @@ The format of the filename is:
 
 .. note::
 
-    The first format without the build information is the release and recommended build format. The second format with 
-    build information is the *SNAPSHOT* format. This version is still in development.
+    The first format without the build information is the *Release* and *Recommended Build* format (e.g., 
+    ``spongeapi-7.1.0-shaded.jar``).
+    
+    The second format with the build information is the *Latest* format when the file is downloaded with a web 
+    browser. This version is still in development (e.g., ``spongeapi-7.2.0-20190224.183500-15-shaded.jar``).
+    
+    The third format without the build information is the *Latest* format when the file is downloaded by Gradle or 
+    Maven or is created by the build process. This version is still in development (e.g., 
+    ``spongeapi-7.2.0-SNAPSHOT.jar``). 
     
     See our `build system 
     <https://docs.spongepowered.org/stable/en/plugin/buildsystem.html#creating-a-plugin-without-a-build-system>`_ page 

--- a/source/versions/filenames.rst
+++ b/source/versions/filenames.rst
@@ -62,13 +62,13 @@ Examples
 
 SpongeForge Jar files will always follow this naming scheme to allow you to easily identify compatibility.
 
-For example, the file name ``spongeforge-1.12.2-2705-7.1.4.jar`` is compatible with Minecraft version ``1.12.2``, was 
-built with Forge ``14.23.4.2705`` (Build ``2705``), guarantees compatibility with SpongeAPI ``7.1.0``, is a recommended 
+For example, the file name ``spongeforge-1.12.2-2768-7.1.4.jar`` is compatible with Minecraft version ``1.12.2``, was 
+built with Forge ``14.23.5.2768`` (Build ``2768``), guarantees compatibility with SpongeAPI ``7.1.0``, is a recommended 
 version, and is the ``4`` th release of SpongeForge with this API.
 
-Another example is the file name ``spongeforge-1.12.2-2705-7.1.5-RC3449.jar``. This file is compatible with Minecraft 
-version ``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), guarantees compatibility with SpongeAPI 
-``7.1.0``, is not a recommended version, and is build number ``3449`` in development, which will be the ``5`` th 
+Another example is the file name ``spongeforge-1.12.2-2768-7.1.5-RC3505.jar``. This file is compatible with Minecraft 
+version ``1.12.2``, was built with Forge ``14.23.5.2768`` (Build ``2768``), guarantees compatibility with SpongeAPI 
+``7.1.0``, is not a recommended version, and is build number ``3505`` in development, which will be the ``5`` th 
 release of SpongeForge once this version is released. 
 
 SpongeVanilla
@@ -77,7 +77,7 @@ SpongeVanilla
 The information for SpongeVanilla is identical to SpongeForge except that SpongeVanilla does not contain a Forge build 
 number. So, the above examples of SpongeForge jar files will look like the following for SpongeVanilla:
 
-``spongevanilla-1.12.2-7.1.4.jar`` and ``spongevanilla-1.12.2-7.1.5-RC3449.jar``
+``spongevanilla-1.12.2-7.1.4.jar`` and ``spongevanilla-1.12.2-7.1.5-RC148.jar``
 
 SpongeAPI
 =========

--- a/source/versions/filenames.rst
+++ b/source/versions/filenames.rst
@@ -5,41 +5,6 @@ Reading the Download Filename
 When you download files, the name of the file will provide some important version information. The following sections 
 describe the information provided.
 
-SpongeAPI
-=========
-
-The format of the filename is:
-
-``spongeapi-<APIMajor>.<LatestAPIMinorRelease>-shaded.jar``
-
-**OR**
-
-``spongeapi-<APIMajor>.<LatestAPIMinorRelease>.<Date>.<Time>-<BuildNumber>-shaded.jar``
-
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``APIMajor``         | The major version of SpongeAPI implemented by this file (the ``X`` in                         |
-|                      | :ref:`semantic versioning<sem-ver>`).                                                         |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``LatestAPI``        | The minor version of SpongeAPI implemented by this file (the ``Y`` in                         |
-| ``MinorRelease``     | :ref:`semantic versioning<sem-ver>`).                                                         |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``Date``             | The date when the build job ran.                                                              |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``Time``             | The time when the build job ran.                                                              |
-+----------------------+-----------------------------------------------------------------------------------------------+
-| ``<BuildNumber>``    | The build number of Sponge. Supply this number when reporting bugs or seeking support.        |
-+----------------------+-----------------------------------------------------------------------------------------------+
-
-.. note::
-
-    The first format without the build information is the release and recommended build format. The second format with 
-    build information is the *SNAPSHOT* format. This version is still in development.
-    
-    See our 
-    `build system 
-    <https://docs.spongepowered.org/stable/en/plugin/buildsystem.html#creating-a-plugin-without-a-build-system>`_ page 
-    for an explanation of the ``-shaded`` label.
-
 .. _sponge-forge-file-name:
 
 SpongeForge
@@ -47,15 +12,13 @@ SpongeForge
 
 .. note::
 
-    Sponge changed our versioning policy in October 2018. **Beginning with** SpongeAPI 8.0, the following information 
+    Our versioning policy was updated in October 2018. **Beginning with** SpongeAPI 8.0, the following information 
     applies. See :doc:`legacy-versions` for information on older versions.
 
 When you download SpongeForge, the name of the file includes a Forge build number which this version of SpongeForge is 
-compatible with. Other builds, even ones differing by only a few build numbers, are not officially supported.
-
-However, SpongeForge usually updates to a new Forge build fairly soon after it's released, so you needn't worry about 
-always having to run an outdated Forge version in order to use SpongeForge.
-
+built with and guaranteed to be compatible. We do not support newer versions of Forge; however, we try to get an update 
+out when a Forge release breaks SpongeForge. You can try the Forge version needed as it will work fine most of the 
+time. If it doesn't, we hope to release a SpongeForge compatible with that Forge version soon. 
 
 The format of the filename is:
 
@@ -74,11 +37,10 @@ The format of the filename is:
 | ``MinorRelease``     | :ref:`semantic versioning<sem-ver>`).                                                         |
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``Recommended``      | The released version of the implementation when **not** followed by ``-RC<BuildNumber>.``     |
-| ``Version``          | When this number is **not** zero, the SpongeAPI version in development is used (i.e. API      |
-|                      | Minor + 1).                                                                                   |
+| ``Version``          |                                                                                               |
 +----------------------+-----------------------------------------------------------------------------------------------+
-| ``-RC``              | The build number in development for the next implementation release. When a build number      |
-| ``<BuildNumber>``    | is present, the ``RecommendedVersion`` has **not** been released yet.                         |
+| ``-RC``              | The build number in development for the next recommended release. When a build number is      |
+| ``<BuildNumber>``    | present, the ``RecommendedVersion`` has **not** been released yet.                            |
 +----------------------+-----------------------------------------------------------------------------------------------+
 
 Examples
@@ -87,13 +49,13 @@ Examples
 SpongeForge Jar files will always follow this naming scheme to allow you to easily identify compatibility.
 
 For example, the file name ``spongeforge-1.12.2-2705-7.1.4.jar`` is compatible with Minecraft version ``1.12.2``, was 
-built with Forge ``14.23.4.2705`` (Build ``2705``), uses SpongeAPI ``7.2-SNAPSHOT``, is a recommended version, and is 
-the ``4`` th release of SpongeForge with this API.
+built with Forge ``14.23.4.2705`` (Build ``2705``), guarantees compatibility with SpongeAPI ``7.1.0``, is a recommended 
+version, and is the ``4`` th release of SpongeForge with this API.
 
 Another example is the file name ``spongeforge-1.12.2-2705-7.1.5-RC3449.jar``. This file is compatible with Minecraft 
-version ``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), uses SpongeAPI ``7.2-SNAPSHOT``, is not a 
-recommended version, and is build number ``3449`` in development, which will be the ``5`` th release of SpongeForge 
-once this version is released. 
+version ``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), guarantees compatibility with SpongeAPI 
+``7.1.0``, is not a recommended version, and is build number ``3449`` in development, which will be the ``5`` th 
+release of SpongeForge once this version is released. 
 
 .. note::
 
@@ -118,4 +80,38 @@ The information for SpongeVanilla is identical to SpongeForge except that Sponge
 number. So, the above examples of SpongeForge jar files will look like the following for SpongeVanilla:
 
 ``spongevanilla-1.12.2-7.1.4.jar`` and ``spongevanilla-1.12.2-7.1.5-RC3449.jar``
+
+SpongeAPI
+=========
+
+The format of the filename is:
+
+``spongeapi-<APIMajor>.<LatestAPIMinorRelease>.0-shaded.jar``
+
+**OR**
+
+``spongeapi-<APIMajor>.<LatestAPIMinorRelease>.0-<Date>.<Time>-<BuildNumber>-shaded.jar``
+
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``APIMajor``         | The major version of SpongeAPI implemented by this file (the ``X`` in                         |
+|                      | :ref:`semantic versioning<sem-ver>`).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``LatestAPI``        | The minor version of SpongeAPI implemented by this file (the ``Y`` in                         |
+| ``MinorRelease``     | :ref:`semantic versioning<sem-ver>`).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``Date``             | The date when the build job ran.                                                              |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``Time``             | The time when the build job ran.                                                              |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``<BuildNumber>``    | The build number of Sponge. Supply this number when reporting bugs or seeking support.        |
++----------------------+-----------------------------------------------------------------------------------------------+
+
+.. note::
+
+    The first format without the build information is the release and recommended build format. The second format with 
+    build information is the *SNAPSHOT* format. This version is still in development.
+    
+    See our `build system 
+    <https://docs.spongepowered.org/stable/en/plugin/buildsystem.html#creating-a-plugin-without-a-build-system>`_ page 
+    for an explanation of the ``-shaded`` label.
 

--- a/source/versions/filenames.rst
+++ b/source/versions/filenames.rst
@@ -30,8 +30,8 @@ The format of the SpongeForge download filename is:
 | ``LatestAPI``        | The minor version of SpongeAPI implemented by this file (the ``Y`` in                         |
 | ``MinorRelease``     | :ref:`semantic versioning<sem-ver>`).                                                         |
 +----------------------+-----------------------------------------------------------------------------------------------+
-| ``Recommended``      | The released version of the implementation when **not** followed by ``-RC<BuildNumber>.``     |
-| ``Version``          |                                                                                               |
+| ``Recommended``      | The released version of the implementation when **not** followed by ``-RC<BuildNumber>`` (the |
+| ``Version``          | ``Z`` in :ref:`semantic versioning<sem-ver>`).                                                |
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``-RC``              | The build number in development for the next recommended release. When a build number is      |
 | ``<BuildNumber>``    | present, the ``RecommendedVersion`` has **not** been released yet.                            |

--- a/source/versions/filenames.rst
+++ b/source/versions/filenames.rst
@@ -49,6 +49,14 @@ of Forge for this purpose.
     whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
     use more recent versions of Forge than the one used for SpongeForge, but we can't always guarantee compatibility.
 
+.. warning::
+
+    When investigating crash issues, you can freely try newer versions of Forge than listed on the SpongeForge Jar.
+    However, it is recommended to also check with the matching version, to make sure your issue is not related to a
+    version mismatch.
+    Even though there will be no guarantee of compatibility, please report any breakage to the issue tracker, so that
+    SpongeForge can be updated.
+
 Examples
 --------
 

--- a/source/versions/filenames.rst
+++ b/source/versions/filenames.rst
@@ -1,0 +1,121 @@
+=============================
+Reading the Download Filename
+=============================
+
+When you download files, the name of the file will provide some important version information. The following sections 
+describe the information provided.
+
+SpongeAPI
+=========
+
+The format of the filename is:
+
+``spongeapi-<APIMajor>.<LatestAPIMinorRelease>-shaded.jar``
+
+**OR**
+
+``spongeapi-<APIMajor>.<LatestAPIMinorRelease>.<Date>.<Time>-<BuildNumber>-shaded.jar``
+
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``APIMajor``         | The major version of SpongeAPI implemented by this file (the ``X`` in                         |
+|                      | :ref:`semantic versioning<sem-ver>`).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``LatestAPI``        | The minor version of SpongeAPI implemented by this file (the ``Y`` in                         |
+| ``MinorRelease``     | :ref:`semantic versioning<sem-ver>`).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``Date``             | The date when the build job ran.                                                              |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``Time``             | The time when the build job ran.                                                              |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``<BuildNumber>``    | The build number of Sponge. Supply this number when reporting bugs or seeking support.        |
++----------------------+-----------------------------------------------------------------------------------------------+
+
+.. note::
+
+    The first format without the build information is the release and recommended build format. The second format with 
+    build information is the *SNAPSHOT* format. This version is still in development.
+    
+    See our 
+    `build system 
+    <https://docs.spongepowered.org/stable/en/plugin/buildsystem.html#creating-a-plugin-without-a-build-system>`_ page 
+    for an explanation of the ``-shaded`` label.
+
+.. _sponge-forge-file-name:
+
+SpongeForge
+===========
+
+.. note::
+
+    Sponge changed our versioning policy in October 2018. **Beginning with** SpongeAPI 8.0, the following information 
+    applies. See :doc:`legacy-versions` for information on older versions.
+
+When you download SpongeForge, the name of the file includes a Forge build number which this version of SpongeForge is 
+compatible with. Other builds, even ones differing by only a few build numbers, are not officially supported.
+
+However, SpongeForge usually updates to a new Forge build fairly soon after it's released, so you needn't worry about 
+always having to run an outdated Forge version in order to use SpongeForge.
+
+
+The format of the filename is:
+
+``spongeforge-<MCVersion>-<ForgeBuild>-<APIMajor>.<LatestAPIMinorRelease>.<RecommendedVersion(-RC<BuildNumber>)>.jar``
+
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``MCVersion``        | The Minecraft version. Only clients compatible with this version can connect.                 |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``ForgeBuild``       | Preferably your server should run this exact version of Forge (which can be identified in the |
+|                      | last part of Forge's version string).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``APIMajor``         | The major version of SpongeAPI implemented by this file (the ``X`` in                         |
+|                      | :ref:`semantic versioning<sem-ver>`).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``LatestAPI``        | The minor version of SpongeAPI implemented by this file (the ``Y`` in                         |
+| ``MinorRelease``     | :ref:`semantic versioning<sem-ver>`).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``Recommended``      | The released version of the implementation when **not** followed by ``-RC<BuildNumber>.``     |
+| ``Version``          | When this number is **not** zero, the SpongeAPI version in development is used (i.e. API      |
+|                      | Minor + 1).                                                                                   |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``-RC``              | The build number in development for the next implementation release. When a build number      |
+| ``<BuildNumber>``    | is present, the ``RecommendedVersion`` has **not** been released yet.                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+
+Examples
+~~~~~~~~
+
+SpongeForge Jar files will always follow this naming scheme to allow you to easily identify compatibility.
+
+For example, the file name ``spongeforge-1.12.2-2705-7.1.4.jar`` is compatible with Minecraft version ``1.12.2``, was 
+built with Forge ``14.23.4.2705`` (Build ``2705``), uses SpongeAPI ``7.2-SNAPSHOT``, is a recommended version, and is 
+the ``4`` th release of SpongeForge with this API.
+
+Another example is the file name ``spongeforge-1.12.2-2705-7.1.5-RC3449.jar``. This file is compatible with Minecraft 
+version ``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), uses SpongeAPI ``7.2-SNAPSHOT``, is not a 
+recommended version, and is build number ``3449`` in development, which will be the ``5`` th release of SpongeForge 
+once this version is released. 
+
+.. note::
+
+    Normal Forge mods can usually run on any build of Forge for a given Minecraft version (e.g. 1.8.0) without any
+    problem. However, SpongeForge needs to access, among other things, internal parts of Forge, which most mods
+    shouldn’t be touching, let alone modifying as Sponge does. Since Forge is free to change their internal code
+    whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
+    use more recent versions of Forge, than the one used for SpongeForge, but we can't always guarantee compatibility.
+
+.. warning::
+
+    When investigating crash issues, you can freely try newer versions of Forge than listed on the SpongeForge Jar.
+    However, it is recommended to also check with the matching version, to make sure your issue is not related to a
+    version mismatch.
+    Even though there will be no guarantee of compatibility, please report any breakage to the issue tracker, so that
+    SpongeForge can be updated.
+
+SpongeVanilla
+=============
+
+The information for SpongeVanilla is identical to SpongeForge except that SpongeVanilla does not contain a Forge build 
+number. So, the above examples of SpongeForge jar files will look like the following for SpongeVanilla:
+
+``spongevanilla-1.12.2-7.1.4.jar`` and ``spongevanilla-1.12.2-7.1.5-RC3449.jar``
+

--- a/source/versions/index.rst
+++ b/source/versions/index.rst
@@ -1,0 +1,16 @@
+=================
+Versioning Policy
+=================
+
+This section describes how Sponge manages versions.
+
+Contents
+========
+
+.. toctree::
+    :maxdepth: 2
+    :titlesonly:
+
+    versioning
+    filenames
+    legacy-versions

--- a/source/versions/legacy-versions.rst
+++ b/source/versions/legacy-versions.rst
@@ -4,22 +4,16 @@ Older Versions of SpongeForge
 
 .. note::
 
-    Our versioning policy was updated in October 2018. **Prior to** SpongeAPI 8.0, the following information applies. 
+    Our versioning policy was updated in October 2018. **Prior to** SpongeAPI 7.1, the following information applies. 
     See :doc:`filenames` for information on newer versions.
 
-When you download SpongeForge, the name of the file includes a Forge build number which this version of SpongeForge is 
-built with and guaranteed to be compatible. We do not support newer versions of Forge; however, we try to get an update 
-out when a Forge release breaks SpongeForge. You can try the Forge version needed as it will work fine most of the 
-time. If it doesn't, we hope to release a SpongeForge compatible with that Forge version soon. 
-
-
-The format of the filename is ``spongeforge-<MCVersion>-<ForgeBuildId>-<SpongeAPIVersion>-BETA-<SpongeBuildId>.jar``
+The format of the SpongeForge download filename is:
+``spongeforge-<MCVersion>-<ForgeBuildId>-<SpongeAPIVersion>-BETA-<SpongeBuildId>.jar``
 
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``MCVersion``        | The Minecraft version. Only clients compatible with this version can connect.                 |
 +----------------------+-----------------------------------------------------------------------------------------------+
-| ``ForgeBuildId``     | Preferably your server should run this exact version of Forge (which can be identified in the |
-|                      | last part of Forge's version string).                                                         |
+| ``ForgeBuild``       | The Forge build that SpongeForge is built against and is guaranteed to be compatible          |
 +----------------------+-----------------------------------------------------------------------------------------------+
 | ``SpongeAPIVersion`` | The version of SpongeAPI implemented by this file. This is what Sponge plugins depend on.     |
 +----------------------+-----------------------------------------------------------------------------------------------+
@@ -27,8 +21,20 @@ The format of the filename is ``spongeforge-<MCVersion>-<ForgeBuildId>-<SpongeAP
 |                      | support.                                                                                      |
 +----------------------+-----------------------------------------------------------------------------------------------+
 
+The Forge Build in the filename specifies the version of Forge this version of SpongeForge used during development and 
+testing. The two versions are guaranteed to work without any issues. We **tend** to use the latest *Recommended Build* 
+of Forge for this purpose.
+
+.. note::
+
+    Normal Forge mods can usually run on any build of Forge for a given Minecraft version (e.g. 1.12.2) without any 
+    problem. However, SpongeForge needs to access, among other things, internal parts of Forge, which most mods
+    shouldn’t be touching, let alone modifying as Sponge does. Since Forge is free to change their internal code
+    whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
+    use more recent versions of Forge than the one used for SpongeForge, but we can't always guarantee compatibility.
+
 Example
-~~~~~~~
+-------
 
 SpongeForge Jar files will always follow this naming scheme, to allow you to easily identify compatibility.
 

--- a/source/versions/legacy-versions.rst
+++ b/source/versions/legacy-versions.rst
@@ -1,0 +1,39 @@
+=============================
+Older Versions of SpongeForge
+=============================
+
+.. note::
+
+    Sponge changed our versioning policy in October 2018. **Prior to** SpongeAPI 8.0, the following information 
+    applies. See :doc:`filenames` for information on newer versions.
+
+When you download SpongeForge, the name of the file will provide some important version information. It includes a
+Forge build number which this version of SpongeForge is compatible with. Other builds, even ones differing by only a
+few build numbers are not officially supported.
+
+However, SpongeForge usually updates to a new Forge build fairly soon after it's released, so you needn't
+worry about always having to run an outdated Forge version in order to use SpongeForge.
+
+
+The format of the filename is ``spongeforge-<MCVersion>-<ForgeBuildId>-<SpongeAPIVersion>-BETA-<SpongeBuildId>.jar``
+
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``MCVersion``        | The Minecraft version. Only clients compatible with this version can connect.                 |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``ForgeBuildId``     | Preferably your server should run this exact version of Forge (which can be identified in the |
+|                      | last part of Forge's version string).                                                         |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``SpongeAPIVersion`` | The version of SpongeAPI implemented by this file. This is what Sponge plugins depend on.     |
++----------------------+-----------------------------------------------------------------------------------------------+
+| ``SpongeBuildId``    | The build number of Sponge. This is what you should supply when reporting bugs or seeking     |
+|                      | support.                                                                                      |
++----------------------+-----------------------------------------------------------------------------------------------+
+
+Example
+~~~~~~~
+
+SpongeForge Jar files will always follow this naming scheme, to allow you to easily identify compatibility.
+
+For example, the file name ``spongeforge-1.12.2-2705-7.1.0-BETA-3442.jar`` is compatible with Minecraft version
+``1.12.2``, was built with Forge ``14.23.4.2705`` (Build ``2705``), provides SpongeAPI ``7.1.0`` and was build number
+``3442`` of SpongeForge.

--- a/source/versions/legacy-versions.rst
+++ b/source/versions/legacy-versions.rst
@@ -4,15 +4,13 @@ Older Versions of SpongeForge
 
 .. note::
 
-    Sponge changed our versioning policy in October 2018. **Prior to** SpongeAPI 8.0, the following information 
-    applies. See :doc:`filenames` for information on newer versions.
+    Our versioning policy was updated in October 2018. **Prior to** SpongeAPI 8.0, the following information applies. 
+    See :doc:`filenames` for information on newer versions.
 
-When you download SpongeForge, the name of the file will provide some important version information. It includes a
-Forge build number which this version of SpongeForge is compatible with. Other builds, even ones differing by only a
-few build numbers are not officially supported.
-
-However, SpongeForge usually updates to a new Forge build fairly soon after it's released, so you needn't
-worry about always having to run an outdated Forge version in order to use SpongeForge.
+When you download SpongeForge, the name of the file includes a Forge build number which this version of SpongeForge is 
+built with and guaranteed to be compatible. We do not support newer versions of Forge; however, we try to get an update 
+out when a Forge release breaks SpongeForge. You can try the Forge version needed as it will work fine most of the 
+time. If it doesn't, we hope to release a SpongeForge compatible with that Forge version soon. 
 
 
 The format of the filename is ``spongeforge-<MCVersion>-<ForgeBuildId>-<SpongeAPIVersion>-BETA-<SpongeBuildId>.jar``

--- a/source/versions/legacy-versions.rst
+++ b/source/versions/legacy-versions.rst
@@ -33,6 +33,14 @@ of Forge for this purpose.
     whenever they want to, its normal guarantee of backwards-compatibility doesn’t apply to SpongeForge. Feel free to
     use more recent versions of Forge than the one used for SpongeForge, but we can't always guarantee compatibility.
 
+.. warning::
+
+    When investigating crash issues, you can freely try newer versions of Forge than listed on the SpongeForge Jar.
+    However, it is recommended to also check with the matching version, to make sure your issue is not related to a
+    version mismatch.
+    Even though there will be no guarantee of compatibility, please report any breakage to the issue tracker, so that
+    SpongeForge can be updated.
+
 Example
 -------
 

--- a/source/versions/versioning.rst
+++ b/source/versions/versioning.rst
@@ -4,115 +4,111 @@ Versioning
 
 .. _sem-ver:
 
-SemVer
-======
+.. tip::
+    Sponge follows a format of the SemVer specification in its projects. You can read about general SemVer usage at 
+    http://semver.org.
 
-Sponge uses the semantic versioning (https://semver.org/) specification. As a result, we increment versions according 
-to the rules of SemVer every time that we make a release.
+The SpongeAPI and implementations (SpongeForge/SpongeVanilla) follow two different policies. Understanding our versions 
+is a matter of interpreting the SemVer version string. The SpongeAPI version utilizes the *Major* and *Minor* parts in 
+the SemVer version string while the implementations use the *Major*, *Minor*, and *Patch* parts.
 
-SemVer uses the scheme ``X.Y.Z``, where ``X`` is a *major* version, ``Y`` is a *minor* version and ``Z`` is a *patch* 
-version. A release containing changes which are not backwards-compatible must be one *major* version ahead of the 
-previous release. If there are only new features that are still backwards compatible, then the new release will be 
-one *minor* version ahead of the previous release, and if the release strictly contains bugfixes then only the *patch* 
-version will be incremented.
+API
+===
 
-This means that ``3.2.0`` is fully compatible to ``3.0.0`` while ``4.0.0`` is not compatible to ``3.0.0``, ``3.1.0``, 
-or ``3.1.2``. These versions are fully compatible also; the difference between them are new features (``3.0.0`` -> 
-``3.1.0``) and bug fixes (``3.1.0`` -> ``3.1.1`` -> ``3.1.2``). ``3.2.0`` introduced more new features beyond those 
-introduced by ``3.1.0``.
+Plugin developers create plugins for a particular SpongeAPI version, such as ``7.0``, ``7.3``, or ``7.9``, so the 
+plugin works with the features provided in that specific version. Versions are incremented to reflect added, removed, 
+or changed features. How the version number changes convey how plugins might be affected.
 
-Version String
-==============
+Major
+-----
 
-Applying the versioning policy to Sponge begins with SpongeAPI. It is the core on which the version string is based. 
-SpongeAPI is the actual API that allows plugins to interact with the game. However, the API is enabled by the Sponge 
-implementation (SpongeForge or SpongeVanilla). Together, these products form the foundation of a Sponge server.
+A change in the Major number (**X**.Y.Z) indicates that changes broke some APIs that were guaranteed to work in the 
+previous version. Plugins *might* break with this kind of version change. For example, a plugin for version 6.9 *might* 
+not run with version 7.0.
 
-As such, the version string reflects the state of these two products. The major and minor release components of a 
-version is based on the API while the patch component of the version is based on the implementation. Let's consider 
-this version string as an example: ``8.2.0``. This string conveys the API is Version 8.2 and the implementation is the 
-first release using this API version.
+Minor
+-----
 
-The following table provides several examples of a version string and its components:
-
-+-----------+---------+----------------+
-|           |         |                |
-| Version   | API     | Implementation |
-|           |         |                |
-+===========+=========+================+
-|           |         |                |
-| ``8.0.2`` | ``8.0`` | ``2``          |
-|           |         |                |
-+-----------+---------+----------------+
-|           |         |                |
-| ``8.1.1`` | ``8.1`` | ``1``          |
-|           |         |                |
-+-----------+---------+----------------+
-|           |         |                |
-| ``8.5.0`` | ``8.5`` | ``0``          |
-|           |         |                |
-+-----------+---------+----------------+
-
-There are two other components of the version string: *SNAPSHOT* and *RC*. Both of these labels indicate a version 
-still in development. These files are used for testing new features and bug fixes, so they are generally used by 
-developers. *SNAPSHOT* is associated with the API, and *RC*, or Release Candidate, is associated with the 
-implementation (SpongeVanilla and SpongeForge).
-
-*SNAPSHOT* and *RC* are **always** associated with a number (e.g., ``1-SNAPSHOT``, ``-RC120``). With *SNAPSHOT*, the 
-number identifies the **next** *minor* release for SpongeAPI. The number associated with *RC* identifies the build 
-number of the implementation and indicates the build is part of the development towards the next 
-implementation/recommended release. 
+A change in the Minor number (X. **Y**.Z) indicates that changes added some APIs, but plugins for previous minor 
+versions in the same major version are still guaranteed to work. For example, a plugin for version ``7.3`` will run 
+with version ``7.4`` or ``7.5``. However, the opposite is not *necessarily* the same. A plugin for version ``7.4`` is 
+not guaranteed to run with version ``7.3``. 
 
 .. note::
 
-    Any file without the *SNAPSHOT* or *RC* label is a released version. A recommended version is a release of an 
-    implementation.
+    The *Minor* number is always reset to zero when the *Major* number changes.
 
-.. tip::
-
-    Keep in mind the diffences between a major release, a minor release, and a patch release while reading the 
-    following.
-
-API
----
-
-An important part to grasp in understanding Sponge versioning is how the version string conveys the API information. 
-The API version is primarily conveyed by the *major* . *minor* labels. The *major* label is always a number. The 
-*minor* label can be just a number, indicating a release, or it can be a number with ``-SNAPSHOT`` appended to it, 
-indicating a **minor release in development**. Developers are the most likely to use snapshots, so most Sponge users 
-can focus on the *major* . *minor* labels to identify which version is represented.
-
-However, the patch release provides important information for understanding which version of the API is represented as 
-well. Even though the API itself does not have patch releases, a Sponge implementation is required to use the 
-SpongeAPI. So, the version string has to convey both API and implementation versions. We achieve this by tying them 
-together and having the implementation release reflect any patch release for the API. This allows the version string to 
-accurately and completely reflect the status of the API *and* the implementation. 
-
-The good news is the policy is straight forward. When the implementation release is ``0``, the API is a release. An 
-example of the version string in this case is ``8.1.0``. When the implementation release is **not** ``0``, the API is 
-in development. An example of the version string in this case is ``8.1.1``. In this example, the API is actually the 
-next version in development (i.e. ``2-SNAPSHOT``). 
+Examples of SpongeAPI version strings are ``spongeapi-7.1.0`` and ``spongeapi-7.2.0``. 
 
 Implementations
----------------
+===============
 
-The patch version for Sponge is added to the version string with the implementation; however, care must be taken to 
-interpret the information correctly. As mentioned above, the patch version provides information about the release 
-status of the API as well as the implementation.
+The version string for the Sponge implementations includes the target Minecraft version as well as the SpongeAPI 
+version. The SpongeForge implementation also specifies the Forge **recommended version** with which it is guaranteed to 
+be compatible.
 
-First, a **zero** in the patch label indicates a release. A full release occurs when a major release occurs (i.e. 
-**zero** in the minor *and* patch components). Examples are ``7.2.0`` and ``8.0.0`` respectively. 
+Patch
+-----
 
-Second, any **non-zero** number in the patch label indicates the next **API minor release in development**. For 
-example, ``spongevanilla-1.12.2-7.1.4`` is using ``7.2`` version of the API (which is in development); it does **NOT** 
-use the ``7.1`` version (which has been released). However, this version is still a **recommended version** because the 
-*RC* label is not used. Plus, it is the ``4`` th recommended version for this implementation.
+A change in the patch number (X.Y. **Z**) occurs with implementation builds. These builds contain bug fixes, 
+performance improvements, configuration changes, and other changes not related to the API. When a patch number is only 
+a number, this build is a **recommended version**. Any plugin developed for the SpongeAPI version in the string, or is  
+compatible with that version, is guaranteed to work.
+
+.. note::
+
+    The *Patch* number is always reset to zero when the *Minor* number changes.
+
+Examples of implementation version strings are ``spongevanilla-1.12.2-7.1.5`` and ``spongeforge-1.12.2-2768-7.1.5``. 
+
+.. warning::
+
+    Plugin developers may choose to develop their plugin for a particular implementation. The plugin's Ore page should 
+    note such decision with a tag by the version. Sponge makes no guarantee of a plugin's compatibility when marked as 
+    such.
+
+Recommended Version
+===================
+
+Recommended Versions are also known as Recommended Builds or Releases. They are versions of reasonable quality of which 
+the implementations can make full use of the functionality available in SpongeAPI, and plugins compatible with the API 
+are guaranteed to work as designed.
+
+.. warning::
+
+    The following information is for Sponge Developers. Plugin Developers and Server Administrators should only use 
+    **Recommended Versions** for development and server installations. Doing otherwise is at your own risk and **not** 
+    encouraged.
+
+SNAPSHOT
+========
+
+A release which has the ``-SNAPSHOT`` label represents the next API version in development. For example, 
+``7.2.0-SNAPSHOT`` means ``7.2.0`` is in development. Another example is ``8.0.0-SNAPSHOT``, which means the next 
+*major* release (``8.0.0``) is in development. New features added in snapshots may break at any time. 
+
+.. note::
+
+    If the minor version is zero (e.g., ``8.0-SNAPSHOT``), **anything** may break before it is released and plugins 
+    cannot expect stability. If the Minor version is greater than zero (e.g., ``7.2-SNAPSHOT``), anything up to the 
+    previous minor version is still guaranteed to work (in this case, ``7.1``). However, anything added since it **may 
+    break** and instability is likely.
+
+    When the minor and patch numbers are zero, and the ``-SNAPSHOT`` label is attached, versions are ``bleeding`` 
+    builds for testing the next version of SpongeAPI only and may break at any time.
+
+    The ``-SNAPSHOT`` label on a SpongeCommon file means the implementation is nearly complete but is still not a 
+    stable release. More importantly, Gradle determines whether or not to append the *-RC{build number}* to the version 
+    string by the presence of the label.
+
+Release Candidate
+=================
+
+Release Candidates (**RC**) are builds in which bug fixes are released for implementations while they are still in 
+development. They are nearly ready for a full release, but require more bug fixes and testing.
+
 
 .. tip::
 
-    ``spongevanilla-1.12.2-7.2.0`` is a released version of the API and a released version of the implementation. It is 
-    also a recommended version because the *RC* label is not used.
-
-Last, a *RC* in the patch version indicates an **implementation version in development**. The implementation is still 
-having features added, bugs fixed, and testing performed for the **next recommended version**. Using the same example 
-above, the version string for this implementation is ``spongevanilla-1.12.2-7.1.5-RC152``.
+    *SNAPSHOT* appears in SpongeAPI and SpongeCommon version strings while *RC* appears in implementation version 
+    strings.

--- a/source/versions/versioning.rst
+++ b/source/versions/versioning.rst
@@ -105,11 +105,8 @@ A release which has the ``-SNAPSHOT`` label represents the next API version in d
 Release Candidate
 =================
 
-Any push made to GitHub which is not a *Recommended Build* is a *Release Candidate*. Any release candidate can become a 
-recommended build. Furthermore, the code may or may not change; the change might occur in a settings file. The 
-resulting build may run as well as a recommended build, or it may not run at all. In the end, a change occurred in the 
-repository, it triggered a build, and the resulting build is not a recommended build. Therefore, it is a release 
-candidate.
+Any push made to GitHub which is not a *Recommended Build* is a *Release Candidate*.  It may become a recommended build 
+after further testing. There is also the possibility that a release candidate might not work correctly.
 
 .. tip::
 

--- a/source/versions/versioning.rst
+++ b/source/versions/versioning.rst
@@ -1,0 +1,118 @@
+==========
+Versioning
+==========
+
+.. _sem-ver:
+
+SemVer
+======
+
+Sponge uses the semantic versioning (https://semver.org/) specification. As a result, we increment versions according 
+to the rules of SemVer every time that we make a release.
+
+SemVer uses the scheme ``X.Y.Z``, where ``X`` is a *major* version, ``Y`` is a *minor* version and ``Z`` is a *patch* 
+version. A release containing changes which are not backwards-compatible must be one *major* version ahead of the 
+previous release. If there are only new features that are still backwards compatible, then the new release will be 
+one *minor* version ahead of the previous release, and if the release strictly contains bugfixes then only the *patch* 
+version will be incremented.
+
+This means that ``3.2.0`` is fully compatible to ``3.0.0`` while ``4.0.0`` is not compatible to ``3.0.0``, ``3.1.0``, 
+or ``3.1.2``. These versions are fully compatible also; the difference between them are new features (``3.0.0`` -> 
+``3.1.0``) and bug fixes (``3.1.0`` -> ``3.1.1`` -> ``3.1.2``). ``3.2.0`` introduced more new features beyond those 
+introduced by ``3.1.0``.
+
+Version String
+==============
+
+Applying the versioning policy to Sponge begins with SpongeAPI. It is the core on which the version string is based. 
+SpongeAPI is the actual API that allows plugins to interact with the game. However, the API is enabled by the Sponge 
+implementation (SpongeForge or SpongeVanilla). Together, these products form the foundation of a Sponge server.
+
+As such, the version string reflects the state of these two products. The major and minor release components of a 
+version is based on the API while the patch component of the version is based on the implementation. Let's consider 
+this version string as an example: ``8.2.0``. This string conveys the API is Version 8.2 and the implementation is the 
+first release using this API version.
+
+The following table provides several examples of a version string and its components:
+
++-----------+---------+----------------+
+|           |         |                |
+| Version   | API     | Implementation |
+|           |         |                |
++===========+=========+================+
+|           |         |                |
+| ``8.0.2`` | ``8.0`` | ``2``          |
+|           |         |                |
++-----------+---------+----------------+
+|           |         |                |
+| ``8.1.1`` | ``8.1`` | ``1``          |
+|           |         |                |
++-----------+---------+----------------+
+|           |         |                |
+| ``8.5.0`` | ``8.5`` | ``0``          |
+|           |         |                |
++-----------+---------+----------------+
+
+There are two other components of the version string: *SNAPSHOT* and *RC*. Both of these labels indicate a version 
+still in development. These files are used for testing new features and bug fixes, so they are generally used by 
+developers. *SNAPSHOT* is associated with the API, and *RC*, or Release Candidate, is associated with the 
+implementation (SpongeVanilla and SpongeForge).
+
+*SNAPSHOT* and *RC* are **always** associated with a number (e.g., ``1-SNAPSHOT``, ``-RC120``). With *SNAPSHOT*, the 
+number identifies the **next** *minor* release for SpongeAPI. The number associated with *RC* identifies the build 
+number of the implementation and indicates the build is part of the development towards the next 
+implementation/recommended release. 
+
+.. note::
+
+    Any file without the *SNAPSHOT* or *RC* label is a released version. A recommended version is a release of an 
+    implementation.
+
+.. tip::
+
+    Keep in mind the diffences between a major release, a minor release, and a patch release while reading the 
+    following.
+
+API
+---
+
+An important part to grasp in understanding Sponge versioning is how the version string conveys the API information. 
+The API version is primarily conveyed by the *major* . *minor* labels. The *major* label is always a number. The 
+*minor* label can be just a number, indicating a release, or it can be a number with ``-SNAPSHOT`` appended to it, 
+indicating a **minor release in development**. Developers are the most likely to use snapshots, so most Sponge users 
+can focus on the *major* . *minor* labels to identify which version is represented.
+
+However, the patch release provides important information for understanding which version of the API is represented as 
+well. Even though the API itself does not have patch releases, a Sponge implementation is required to use the 
+SpongeAPI. So, the version string has to convey both API and implementation versions. We achieve this by tying them 
+together and having the implementation release reflect any patch release for the API. This allows the version string to 
+accurately and completely reflect the status of the API *and* the implementation. 
+
+The good news is the policy is straight forward. When the implementation release is ``0``, the API is a release. An 
+example of the version string in this case is ``8.1.0``. When the implementation release is **not** ``0``, the API is 
+in development. An example of the version string in this case is ``8.1.1``. In this example, the API is actually the 
+next version in development (i.e. ``2-SNAPSHOT``). 
+
+Implementations
+---------------
+
+The patch version for Sponge is added to the version string with the implementation; however, care must be taken to 
+interpret the information correctly. As mentioned above, the patch version provides information about the release 
+status of the API as well as the implementation.
+
+First, a **zero** in the patch label indicates a release. A full release occurs when a major release occurs (i.e. 
+**zero** in the minor *and* patch components). Examples are ``7.2.0`` and ``8.0.0`` respectively. 
+
+Second, any **non-zero** number in the patch label indicates the next **API minor release in development**. For 
+example, ``spongevanilla-1.12.2-7.1.4`` is using ``7.2`` version of the API (which is in development); it does **NOT** 
+use the ``7.1`` version (which has been released). However, this version is still a **recommended version** because the 
+*RC* label is not used. Plus, it is the ``4`` th recommended version for this implementation.
+
+.. tip::
+
+    ``spongevanilla-1.12.2-7.2.0`` is a released version of the API and a released version of the implementation. It is 
+    also a recommended version because the *RC* label is not used.
+
+Last, a *RC* in the patch version indicates an **implementation version in development**. The implementation is still 
+having features added, bugs fixed, and testing performed for the **next recommended version**. Using the same example 
+above, the version string for this implementation is ``spongevanilla-1.12.2-7.1.5-RC152``.

--- a/source/versions/versioning.rst
+++ b/source/versions/versioning.rst
@@ -77,8 +77,9 @@ are guaranteed to work as designed.
 .. warning::
 
     The following information is for Sponge Developers. Plugin Developers and Server Administrators should only use 
-    **Recommended Versions** for development and server installations. Doing otherwise is at your own risk and **not** 
-    encouraged.
+    **Recommended Versions** for development and server installations. Using a version that is not a recommended build 
+    introduces instability and nearly guarantees problems. We strongly discourage the use of non-recommended builds by 
+    Plugin Developers and Server Administrators.
 
 SNAPSHOT
 ========
@@ -104,9 +105,11 @@ A release which has the ``-SNAPSHOT`` label represents the next API version in d
 Release Candidate
 =================
 
-Release Candidates (**RC**) are builds in which bug fixes are released for implementations while they are still in 
-development. They are nearly ready for a full release, but require more bug fixes and testing.
-
+Any push made to GitHub which is not a *Recommended Build* is a *Release Candidate*. Any release candidate can become a 
+recommended build. Furthermore, the code may or may not change; the change might occur in a settings file. The 
+resulting build may run as well as a recommended build, or it may not run at all. In the end, a change occurred in the 
+repository, it triggered a build, and the resulting build is not a recommended build. Therefore, it is a release 
+candidate.
 
 .. tip::
 


### PR DESCRIPTION
This PR addresses SpongeDocs #768 and [SpongeForge Issue #2367](https://github.com/SpongePowered/SpongeForge/issues/2367).

It changes SpongeDocs by creating a new directory for the topic and adding pages explaining how Sponge manages versions. It also updates existing files to move version topics to one place within the SpongeDocs contents and adds references from existing locations to the new pages. The home page is also updated to reference the new pages.

The first commit updates SpongeDocs to provide the current Java version update shipped with the Mojang installer (1.8.0_74). This information is on the Minecraft Wiki for the Windows versions; I downloaded the Mac OS X  version and confirmed 1.8.0_74 is inside the .dmg file. 