### PR TITLE
Update to config list + tool

### DIFF
--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -525,7 +525,7 @@ world-enabled
 
 ------------------------------------------------------------------------------------------------------------
 
-This config was generated using SpongeForge build 3442 (with Forge 2768), SpongeAPI version 7.1.5:
+This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 with Forge 2768), SpongeAPI version 7.1:
 
 .. code-block:: guess
 
@@ -544,7 +544,7 @@ This config was generated using SpongeForge build 3442 (with Forge 2768), Sponge
             # A list of mod ids that have broken network handlers (they interact with the game from a Netty handler thread).
             # All network handlers from a forcibly scheduled to run on the main thread.
             # Note that this setting should be considered a last resort, and should only be used as a stopgap measure while waiting for a mod to properly fix the issue.
-            broken-network-handler-mods=null
+            broken-network-handler-mods=[]
         }
         bungeecord {
             # If 'true', allows BungeeCord to forward IP address, UUID, and Game Profile to this server.
@@ -910,7 +910,7 @@ This config was generated using SpongeForge build 3442 (with Forge 2768), Sponge
         }
         player-block-tracker {
             # Block IDs that will be blacklisted for player block placement tracking.
-            block-blacklist=null
+            block-blacklist=[]
             # If 'true', adds player tracking support for block positions.
             # Note: This should only be disabled if you do not care who caused a block to change.
             enabled=true
@@ -949,10 +949,10 @@ This config was generated using SpongeForge build 3442 (with Forge 2768), Sponge
             # a safe block for players to warp into.
             # You should only list blocks here that are incorrectly selected, solid blocks that prevent
             # movement are automatically excluded.
-            unsafe-body-block-ids=null
+            unsafe-body-block-ids=[]
             # Block IDs that are listed here will not be selected by Sponge's safe
             # teleport routine as a safe floor block.
-            unsafe-floor-block-ids=null
+            unsafe-floor-block-ids=[]
         }
         tileentity-activation {
             # If 'true', newly discovered tileentities will be added to this config with default settings.

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -538,7 +538,7 @@ This config was generated using SpongeForge build 3442 (with Forge 2768), Sponge
     # # Forums: https://forums.spongepowered.org/
     #
 
-        sponge {
+    sponge {
         # Stopgap measures for dealing with broken mods
         broken-mods {
             # A list of mod ids that have broken network handlers (they interact with the game from a Netty handler thread).
@@ -1064,5 +1064,5 @@ This config was generated using SpongeForge build 3442 (with Forge 2768), Sponge
             weather-thunder=true
             # If 'true', this world will be registered.
             world-enabled=true
-            }
         }
+    }

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,3 +5,4 @@ This package contains a number of tools that help maintaining the docs.
 
 * [Javadoc-Checker](javadoc-checker) - Checks imports and javadoc-references
 * [Code-Checker](code-checker) - Extracts code blocks and wraps them in proper classes
+* [Config-Lister](config-lister) - Plugin that creates a list of config options from the global.conf file

--- a/tools/config-lister/LICENSE.txt
+++ b/tools/config-lister/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) SpongePowered <https://www.spongepowered.org>
+Copyright (c) contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/config-lister/README.md
+++ b/tools/config-lister/README.md
@@ -1,0 +1,10 @@
+Config-Lister
+=============
+
+A sponge plugin that grabs the config options from the global.conf file and creates a short list for use in the docs.
+
+Usage
+-----
+
+Use `grade build` to build and drop into the plugins folder. Run the server and a `config-dictionary.txt` file will be
+created.

--- a/tools/config-lister/build.gradle
+++ b/tools/config-lister/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+    id 'maven'
+}
+
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
+repositories {
+    mavenCentral()
+    maven {
+        name 'Sponge maven repo'
+        url 'http://repo.spongepowered.org/maven/'
+    }
+}
+
+dependencies {
+    compile 'org.spongepowered:spongeapi:7.0.0'
+}

--- a/tools/config-lister/gradle.properties
+++ b/tools/config-lister/gradle.properties
@@ -1,0 +1,4 @@
+name=ConfigLister
+organization=SpongePowered
+url=https://www.spongepowered.org
+

--- a/tools/config-lister/pom.xml
+++ b/tools/config-lister/pom.xml
@@ -1,0 +1,90 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.spongepowered.docs.tools</groupId>
+	<artifactId>config-lister</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<name>SpongeDocs global.conf Documenation Generator</name>
+	<description>A helper plugin to generate the sponge global.conf documentation.</description>
+	<url>https://docs.spongepowered.org/</url>
+	<inceptionYear>2019</inceptionYear>
+
+	<licenses>
+		<license>
+			<name>The MIT License</name>
+			<url>https://opensource.org/licenses/MIT</url>
+		</license>
+	</licenses>
+
+	<organization>
+		<name>SpongePowered</name>
+		<url>https://www.spongepowered.org/</url>
+	</organization>
+
+	<properties>
+		<sponge.api.version>7.1.0</sponge.api.version>
+
+		<java.version>1.8</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+
+		<charset>UTF-8</charset>
+		<project.reporting.outputEncoding>${charset}</project.reporting.outputEncoding>
+		<project.build.sourceEncoding>${charset}</project.build.sourceEncoding>
+
+		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>sponge</id>
+			<url>https://repo.spongepowered.org/maven</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.spongepowered</groupId>
+			<artifactId>spongeapi</artifactId>
+			<version>${sponge.api.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<defaultGoal>clean package exec:java</defaultGoal>
+		<resources>
+			<resource>
+				<directory>.</directory>
+				<includes>
+					<include>LICENSE.txt</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+						</manifest>
+						<manifestEntries>
+							<build-timestamp>${maven.build.timestamp}</build-timestamp>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -1,0 +1,102 @@
+/**
+ * This file is part of ConfigLister, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.spongepowered.docs.tools.configlister;
+
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.game.state.GameStartedServerEvent;
+import org.spongepowered.api.plugin.Plugin;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+@Plugin(id = "configlister", name = "Config Lister", version = "1.0", description = "Config Lister!")
+public class ConfigLister {
+
+    private final Path configLocation = Paths.get("config/sponge/global.conf").toAbsolutePath();
+    private final Path configDictLoc = Paths.get("config-dictionary.txt").toAbsolutePath();
+    private List<String> toWrite = new ArrayList<>();
+
+    @Listener
+    public void onStarted(GameStartedServerEvent event) {
+        try {
+            CommentedConfigurationNode rootNode = HoconConfigurationLoader.builder().setPath(this.configLocation)
+                    .build().load();
+            this.loopEntries(rootNode.getChildrenMap().get("sponge"));
+
+            Files.write(this.configDictLoc, this.toWrite, Charset.forName("UTF-8"), StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loopEntries(CommentedConfigurationNode node) {
+        if (node.getParent().getKey() != null) {
+            // Ip-sets is empty, config-enabled is for older sponge versions
+            if (node.getParent().getKey().equals("sponge") && !node.getKey().equals("config-enabled") && !node.getKey().equals("ip-sets")) {
+                this.toWrite.add(System.lineSeparator() + node.getKey() + System.lineSeparator()
+                        + StringUtils.repeat('=', node.getKey().toString().length()) + System.lineSeparator());
+            }
+        }
+        if (node.hasMapChildren()) {
+            List<CommentedConfigurationNode> listNode = new ArrayList<>(node.getChildrenMap().values());
+
+            listNode.sort((o1, o2) -> o1.getKey().toString().compareTo(o2.getKey().toString()));
+
+            for (CommentedConfigurationNode childNode : listNode) {
+                if (childNode.getComment().isPresent()) {
+                    this.toWrite.add(childNode.getKey() + this.fixComments(childNode.getComment().get()));
+                }
+                this.loopEntries(childNode);
+            }
+        }
+    }
+
+    private String fixComments(String comment) {
+        String[] splitComment = comment.split("\\r?\\n");
+        if (splitComment.length == 1) {
+            return System.lineSeparator() + "   " + comment;
+        }
+        String fixedComment = "";
+        for (String comment2 : splitComment) {
+            // This if statement fixes a bug where some comment lines would
+            // only be whitespace with no actual content
+            if (!comment2.trim().isEmpty()) {
+                fixedComment += System.lineSeparator() + "   " + comment2;
+            }
+        }
+        return fixedComment;
+    }
+}


### PR DESCRIPTION
Sorry this took wayyy too long to get around to, but here it is.

I'm not sure what version of the config list we want to maintain (latest stable (e.g. 7.1.5), latest release (7.1), or just w/e) but I've updated it here to show the tool.

It's a plugin that creates a file in the root directory of the server (`config-dictionary.txt`) from there you copy + paste into the docs conf file. It does this by fetching child nodes recursively to map out and format the config list. It wouldn't be difficult if we decide to expand the list to include more info like the table did (default value, value type, etc.) in the future.