### PR TITLE
Change guideline relating to line count for PRs

### DIFF
--- a/source/contributing/guidelines.rst
+++ b/source/contributing/guidelines.rst
@@ -28,9 +28,10 @@ General steps
    issues we need your help with.
 
 .. note::
-    Please don't submit pull requests for small, non-functional changes such as fixing typos or renaming variable names. Instead, `join #sponge on IRC (irc.esper.net)
-    <https://webchat.esper.net/?channels=sponge>`_ or `join #spongedev on IRC (irc.esper.net)
-    <https://webchat.esper.net/?channels=spongedev>`_ and we'll change it together with the other smaller changes.
+    Please don't submit pull requests for small, non-functional changes such as fixing typos or renaming variable names.
+    Instead, `join #sponge on IRC (irc.esper.net) <https://webchat.esper.net/?channels=sponge>`_ or 
+    `join #spongedev on IRC (irc.esper.net) <https://webchat.esper.net/?channels=spongedev>`_ and we'll change it
+    together with the other smaller changes.
 
 4. If the issue requires a bigger change you may want to submit the issues without the necessary changes first, so we
    can confirm the issue and know that you're working on fixing it. You should also create a WIP (work in process) pull

--- a/source/contributing/guidelines.rst
+++ b/source/contributing/guidelines.rst
@@ -28,7 +28,7 @@ General steps
    issues we need your help with.
 
 .. note::
-    Please don't submit pull request for small changes under 20 lines. Instead, `join #sponge on IRC (irc.esper.net)
+    Please don't submit pull requests for small changes such as typos or identifier refactoring. Instead, `join #sponge on IRC (irc.esper.net)
     <https://webchat.esper.net/?channels=sponge>`_ or `join #spongedev on IRC (irc.esper.net)
     <https://webchat.esper.net/?channels=spongedev>`_ and we'll change it together with the other smaller changes.
 

--- a/source/contributing/guidelines.rst
+++ b/source/contributing/guidelines.rst
@@ -31,7 +31,8 @@ General steps
     Please don't submit pull requests for small, non-functional changes such as fixing typos or renaming variable names.
     Instead, `join #sponge on IRC (irc.esper.net) <https://webchat.esper.net/?channels=sponge>`_ or 
     `join #spongedev on IRC (irc.esper.net) <https://webchat.esper.net/?channels=spongedev>`_ and we'll change it
-    together with the other smaller changes.
+    together with the other smaller changes. You can also add it to our list of 
+    `Minor Issues on GitHub <https://github.com/search?q=org%3ASpongePowered+Ongoing+Minor+Issue+List&type=Issues>`_.
 
 4. If the issue requires a bigger change you may want to submit the issues without the necessary changes first, so we
    can confirm the issue and know that you're working on fixing it. You should also create a WIP (work in process) pull

--- a/source/contributing/guidelines.rst
+++ b/source/contributing/guidelines.rst
@@ -28,7 +28,7 @@ General steps
    issues we need your help with.
 
 .. note::
-    Please don't submit pull requests for small changes such as typos or identifier refactoring. Instead, `join #sponge on IRC (irc.esper.net)
+    Please don't submit pull requests for small, non-functional changes such as fixing typos or renaming variable names. Instead, `join #sponge on IRC (irc.esper.net)
     <https://webchat.esper.net/?channels=sponge>`_ or `join #spongedev on IRC (irc.esper.net)
     <https://webchat.esper.net/?channels=spongedev>`_ and we'll change it together with the other smaller changes.
 


### PR DESCRIPTION
The rule against PRs that are fewer than 20 lines assumes that those PRs are for things like typos or insignificant things. In some cases, as with my only PR to Sponge, it takes 1 line to fix a crash after the author of the offending code has gone to bed. The number of lines is arbitrary, the importance of the change is not. This change better reflects the intent of the original policy.