### PR TITLE
Add warning for Quick Edit Mode

### DIFF
--- a/source/server/getting-started/launch-script.rst
+++ b/source/server/getting-started/launch-script.rst
@@ -33,8 +33,8 @@ Save your Windows launch script as ``launch.bat``.
 .. warning::
    Launching your server in a Command Prompt or PowerShell environment can lead to the server hanging due to the 
    ``Quick Edit Mode`` of these shells. This mode freezes the process when you highlight something or click inside the 
-   console window. During this time, the only messages captured in the log state the server skipped many seconds or 
-   minutes worth of ticks. You can prevent hangs from occurring by not highlighting any text on the screen and not 
+   console window. During this time, messages captured in the log will state that the server skipped many seconds or 
+   minutes worth of ticks. You can prevent this from occurring by not highlighting any text on the screen and not 
    clicking inside the window, or by disabling the ``Quick Edit Mode`` in the Properties dialogue.
 
 macOS

--- a/source/server/getting-started/launch-script.rst
+++ b/source/server/getting-started/launch-script.rst
@@ -31,11 +31,11 @@ Windows
 Save your Windows launch script as ``launch.bat``.
 
 .. warning::
-   Launching your server in a Command Prompt or PowerShell environment can lead to the server hanging. During this 
-   time, messages captured in the log will state the server skipped many seconds or minutes worth of ticks. The cause 
-   is the ``Quick Edit Mode`` of these shells, which freezes the process when you mark (or highlight) something for a 
-   quick edit (e.g., copy/paste). You can prevent this from occurring by not highlighting any text on the screen, or by 
-   disabling the ``Quick Edit Mode`` in the Properties dialogue.
+   Launching your server in a Command Prompt or PowerShell environment can lead to the server hanging due to the 
+   ``Quick Edit Mode`` of these shells. This mode freezes the process when you highlight something or click inside the 
+   console window. During this time, the only messages captured in the log state the server skipped many seconds or 
+   minutes worth of ticks. You can prevent hangs from occurring by not highlighting any text on the screen and not 
+   clicking inside the window, or by disabling the ``Quick Edit Mode`` in the Properties dialogue.
 
 macOS
 ~~~~~

--- a/source/server/getting-started/launch-script.rst
+++ b/source/server/getting-started/launch-script.rst
@@ -32,10 +32,10 @@ Save your Windows launch script as ``launch.bat``.
 
 .. warning::
    Launching your server in a Command Prompt or PowerShell environment can lead to the server hanging. During this 
-   time, the only messages captured in the log state the server skipped many seconds or minutes worth of ticks. 
-   The cause is the ``Quick Edit Mode`` of these shells. This mode freezes the process when you mark (or highlight) 
-   something for a quick edit (e.g., copy/paste). You can prevent hangs from occurring by not highlighting any text on 
-   the screen or by disabling the ``Quick Edit Mode`` in the Properties dialogue.
+   time, messages captured in the log will state the server skipped many seconds or minutes worth of ticks. The cause 
+   is the ``Quick Edit Mode`` of these shells, which freezes the process when you mark (or highlight) something for a 
+   quick edit (e.g., copy/paste). You can prevent this from occurring by not highlighting any text on the screen, or by 
+   disabling the ``Quick Edit Mode`` in the Properties dialogue.
 
 macOS
 ~~~~~

--- a/source/server/getting-started/launch-script.rst
+++ b/source/server/getting-started/launch-script.rst
@@ -30,6 +30,26 @@ Windows
 
 Save your Windows launch script as ``launch.bat``.
 
+.. warning::
+   Launching your server in a Command Prompt or PowerShell environment can lead to the server randomly hanging. During 
+   this time, the only messages captured in the log state the server skipped many seconds or minutes worth of ticks. 
+   The cause is the ``Quick Edit Mode`` of these shells. This mode freezes the process when you mark something for a 
+   quick edit. You can disable the ``Quick Edit Mode`` in the Properties dialogue to prevent the hangs from occurring.
+
+Disabling Quick Edit Mode
++++++++++++++++++++++++++
+
+.. note::
+   The ``Defaults`` menu and the ``Properties`` menu of both shells are the same, except that changes made in the 
+   ``Defaults`` menu apply to new instances.
+
+To disable ``Quick Edit Mode`` in either shell, 
+
+1. Right-click on the window's icon and click on ``Properties``
+#. Click on the ``Options`` tab
+#. Uncheck ``Quick Edit Mode`` in the ``Edit Options`` section.
+#. Click ``OK``.
+
 macOS
 ~~~~~
 

--- a/source/server/getting-started/launch-script.rst
+++ b/source/server/getting-started/launch-script.rst
@@ -31,24 +31,11 @@ Windows
 Save your Windows launch script as ``launch.bat``.
 
 .. warning::
-   Launching your server in a Command Prompt or PowerShell environment can lead to the server randomly hanging. During 
-   this time, the only messages captured in the log state the server skipped many seconds or minutes worth of ticks. 
-   The cause is the ``Quick Edit Mode`` of these shells. This mode freezes the process when you mark something for a 
-   quick edit. You can disable the ``Quick Edit Mode`` in the Properties dialogue to prevent the hangs from occurring.
-
-Disabling Quick Edit Mode
-+++++++++++++++++++++++++
-
-.. note::
-   The ``Defaults`` menu and the ``Properties`` menu of both shells are the same, except that changes made in the 
-   ``Defaults`` menu apply to new instances.
-
-To disable ``Quick Edit Mode`` in either shell, 
-
-1. Right-click on the window's icon and click on ``Properties``
-#. Click on the ``Options`` tab
-#. Uncheck ``Quick Edit Mode`` in the ``Edit Options`` section.
-#. Click ``OK``.
+   Launching your server in a Command Prompt or PowerShell environment can lead to the server hanging. During this 
+   time, the only messages captured in the log state the server skipped many seconds or minutes worth of ticks. 
+   The cause is the ``Quick Edit Mode`` of these shells. This mode freezes the process when you mark (or highlight) 
+   something for a quick edit (e.g., copy/paste). You can prevent hangs from occurring by not highlighting any text on 
+   the screen or by disabling the ``Quick Edit Mode`` in the Properties dialogue.
 
 macOS
 ~~~~~


### PR DESCRIPTION
[SpongeDocs](https://github.com/SpongePowered/SpongeDocs/issues/797)

This PR adds a warning to the [Creating A Launch Script](https://docs.spongepowered.org/stable/en/server/getting-started/launch-script.html) page of Getting Started in the SpongeDocs. It also provides steps to disabling the `Quick Edit Mode` in Command Prompt and PowerShell shells.

Signed-off-by: Grauldon <17791090+Grauldon@users.noreply.github.com>