### PR TITLE
stopFilter() method continues ray casting

### DIFF
--- a/source/plugin/ray-tracing.rst
+++ b/source/plugin/ray-tracing.rst
@@ -38,10 +38,11 @@ Filtering
 =========
 
 Filters determine what blocks are accepted by the ``BlockRay``. To add a filter, use the ``BlockRayBuilder#stopFilter``
-or ``BlockRayBuilder#skipFilter`` method, passing in one or many ``Predicate<BlockRayHit<E>>``\ s (where ``E`` extends ``Extent``). The ``BlockRayBuilder#stopFilter`` stops the ray cast when it hits a block that passes the given filter 
-and the ``BlockRayBuilder#skipFilter`` skips all blocks that pass the filter. These filters can be chained together
-to create a complex ``BlockRay``. 
-For convenience,``BlockRay`` contains the following methods for common filter use cases:
+or ``BlockRayBuilder#skipFilter`` method, passing in one or many ``Predicate<BlockRayHit<E>>``\ s (where ``E`` extends 
+``Extent``). The ``BlockRayBuilder#stopFilter`` continues the ray cast when it hits a block that passes the given 
+filter and the ``BlockRayBuilder#skipFilter`` skips all blocks that pass the filter. These filters can be chained 
+together to create a complex ``BlockRay``. For convenience, ``BlockRay`` contains the following methods for common 
+filter use cases:
 
  * ``allFilter``: returns a filter accepting all blocks
  * ``onlyAirFilter``: returns a filter accepting only air
@@ -62,7 +63,7 @@ Finally, use :javadoc:`BlockRay.BlockRayBuilder#build()` to finish building the 
 
     Player player;
     BlockRay<World> blockRay = BlockRay.from(player)
-        .stopFilter(BlockRay.continueAfterFilter(BlockRay.onlyAirFilter(), 1)).build();
+        .skipFilter(BlockRay.onlyAirFilter()).stopFilter(BlockRay.onlyAirFilter()).build();
 
 We can rewrite the above to use ``BlockRay#skipFilter(Predicate<BlockRayHit>)`` in addition to 
 ``BlockRay#stopFilter(Predicate<BlockRayHit>)``. This will skip all air blocks and stop at the first non-air block it


### PR DESCRIPTION
[SpongeDocs](https://docs.spongepowered.org/stable/en/) | [Ray Tracing](https://docs.spongepowered.org/stable/en/plugin/ray-tracing.html)

This request updates the Ray Tracing documentation per SpongeDocs issue #817.

Currently, the documentation states the BlockRayBuilder class stops ray casting when the stopFilter() method encounters a block of the specified filter. However, the opposite is true since the class negates the return value of the stopFilter() method when stopping the cast. The Ray Tracing page is updated to state the class continues the casting. Also, the code block example is updated to reflect the correct use of the stopFilter() method. 

Two unrelated changes are included in the PR as well:

1.) a missing space is added on line 44
2.) a block of text is reformatted to comply with line 13 of the [writing guidelines](https://docs.spongepowered.org/stable/en/contributing/spongedocs.html#style-guide) for SpongeDocs