### PR TITLE
[Ore] Download project version now takes an api version

### DIFF
--- a/source/ore/routes/download.rst
+++ b/source/ore/routes/download.rst
@@ -2,12 +2,7 @@
 Download Project Version
 ========================
 
-**GET /api/projects/:pluginId/versions/:version/download**
+**GET /api/v1/projects/:pluginId/versions/:version/download**
 
 Returns a file stream for the specified version within the specified project. The ``:version`` parameter may be replaced
 with ``recommended`` to download the project's current recommended version.
-
-**GET /api/projects/:pluginId/versions/:version/signature**
-
-Returns the pgp signature file stream for the above file. This signature file can be used to verify that the download
-was not modified/corrupted in any way and was uploaded by the correct author.

--- a/source/ore/routes/download.rst
+++ b/source/ore/routes/download.rst
@@ -2,10 +2,6 @@
 Download Project Version
 ========================
 
-.. note::
-
-    Please note that this endpoint does **not** use an ore web api version infix such as ``/api/v1/``.
-
 **GET /api/projects/:pluginId/versions/:version/download**
 
 Returns a file stream for the specified version within the specified project. The ``:version`` parameter may be replaced


### PR DESCRIPTION
The endpoint to download a project version now accepts an API version. Currently only v1 is supported as we haven't developed this part of the v2 API yet.

v2 API will likely go on Ore's API docs when it's ready.