### PR TITLE
Add config lister tool - make config page translatable

### DIFF
--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -1519,7 +1519,7 @@ StructureSave
   | structures from saving, leave this ``enabled=true``. When ``true``, the
   | modification allows for specific ``named`` structures to NOT be saved to
   | disk. Examples of some structures that are costly and somewhat irrelivent
-  | is 'mineshaft's, as they build several structures and save, even after
+  | is ``mineshaft``\s, as they build several structures and save, even after
   | finished generating.
   | **Type:** ``boolean``
   | **Default:** ``false``

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -15,9 +15,9 @@ full example of an unmodified ``global.conf`` file at the bottom of this page, b
 
 .. note::
 
-    The following section headings refer to the simple class names of the configuration classes. Each of the entries in
-    a section refers to a configurable property in the associated class. The `Type` information refers to the
-    section/class that describes the nested configuration structure.
+    The following section headings refer to the path within the configuration (and the corresponding simple class name).
+    Each of the entries in a section refers to a configurable property in the associated class. The `Type` information
+    refers to the section/class that describes the nested configuration structure.
 
 .. _ConfigType_GlobalConfig:
 

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -186,6 +186,142 @@ bungeecord (BungeeCord)
   | **Default:** ``false``
   |
 
+.. _ConfigType_PhaseTracker:
+
+cause-tracker (PhaseTracker)
+----------------------------
+
+* **auto-fix-null-source-block-providing-tile-entities**
+
+  | A mapping that is semi-auto-populating for TileEntities whose types
+  | are found to be providing ``null`` Block sources as neighbor notifications
+  | that end up causing crashes or spam reports. If the value is set to 
+  | ``true``, then a ``workaround`` will be attempted. If not, the 
+  | current BlockState at the target source will be queried from the world.
+  | This map having a specific
+  | entry of a TileEntity will prevent a log or warning come up to any logs
+  | when that ``null`` arises, and Sponge will self-rectify the TileEntity
+  | by calling the method ``getBlockType()``. It is advised that if the mod
+  | id in question is coming up, that the mod author is notified about the
+  | error-prone usage of the field ``blockType``. You can refer them to
+  | the following links for the issue:
+  |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
+  |  https://github.com/SpongePowered/SpongeForge/issues/2787
+  | Also, please provide them with these links for the example PR to
+  | fix the issue itself, as the fix is very simple:
+  | https://github.com/TehNut/Soul-Shards-Respawn/pull/24
+  | https://github.com/Epoxide-Software/Enchanting-Plus/pull/135
+  | **Type:** ``Map<String, Boolean>``
+  |
+
+* **capture-async-spawning-entities**
+
+  | If set to ``true``, when a mod or plugin attempts to spawn an entity 
+  | off the main server thread, Sponge will automatically 
+  | capture said entity to spawn it properly on the main 
+  | server thread. The catch to this is that some mods are 
+  | not considering the consequences of spawning an entity 
+  | off the server thread, and are unaware of potential race 
+  | conditions they may cause. If this is set to false, 
+  | Sponge will politely ignore the entity being spawned, 
+  | and emit a warning about said spawn anyways.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **generate-stacktrace-per-phase**
+
+  | If ``true``, more thorough debugging for PhaseStates 
+  | such that a StackTrace is created every time a PhaseState 
+  | switches, allowing for more fine grained troubleshooting 
+  | in the cases of runaway phase states. Note that this is 
+  | not extremely performant and may have some associated costs 
+  | with generating the stack traces constantly.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **max-block-processing-depth**
+
+  | The maximum number of times to recursively process transactions in a single phase.
+  | Some mods may interact badly with Sponge's block capturing system, causing Sponge to
+  | end up capturing block transactions every time it tries to process an existing batch.
+  | Due to the recursive nature of the depth-first processing that Sponge uses to handle block transactions,
+  | this can result in a stack overflow, which causes us to lose all infomration about the original cause of the issue.
+  | To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds
+  | this threshold.
+  | The default value should almost always work properly -  it's unlikely you'll ever have to change it.
+  | **Type:** ``int``
+  | **Default:** ``1000``
+  |
+
+* **maximum-printed-runaway-counts**
+
+  | If verbose is not enabled, this restricts the amount of 
+  | runaway phase state printouts, usually happens on a server 
+  | where a PhaseState is not completing. Although rare, it should 
+  | never happen, but when it does, sometimes it can continuously print 
+  | more and more. This attempts to placate that while a fix can be worked on 
+  | to resolve the runaway. If verbose is enabled, they will always print.
+  | **Type:** ``int``
+  | **Default:** ``3``
+  |
+
+* **report-null-source-blocks-on-neighbor-notifications**
+
+  | If true, when a mod attempts to perform a neighbor notification
+  | on a block, some mods do not know to perform a ``null`` check
+  | on the source block of their TileEntity. This usually goes by
+  | unnoticed by other mods, because they may perform ``==`` instance
+  | equality checks instead of calling methods on the potentially
+  | null Block, but Sponge uses the block to build information to
+  | help tracking. This has caused issues in the past. Generally,
+  | this can be useful for leaving ``true`` so a proper report is
+  | generated once for your server, and can be reported to the
+  | offending mod author.
+  | This is ``false`` by default in SpongeVanilla.
+  | Review the following links for more info:
+  |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
+  |  https://github.com/SpongePowered/SpongeForge/issues/2787
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **resync-commands-from-async**
+
+  | If set to ``true``, when a mod or plugin attempts to submit a command
+  | asynchronously, Sponge will automatically capture said command
+  | and submit it for processing on the server thread. The catch to
+  | this is that some mods are performing these commands in vanilla
+  | without considering the possible consequences of such commands
+  | affecting any thread-unsafe parts of Minecraft, such as worlds,
+  | block edits, entity spawns, etc. If this is set to false, Sponge
+  | will politely ignore the command being executed, and emit a warning
+  | about said command anyways.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **verbose**
+
+  | If ``true``, the phase tracker will print out when there are too many phases 
+  | being entered, usually considered as an issue of phase re-entrance and 
+  | indicates an unexpected issue of tracking phases not to complete. 
+  | If this is not reported yet, please report to Sponge. If it has been 
+  | reported, you may disable this.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **verbose-errors**
+
+  | If ``true``, the phase tracker will dump extra information about the current phases 
+  | when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information 
+  | in the exception itself can normally be used to determine the cause of the issue
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
 .. _ConfigType_Commands:
 
 commands (Commands)
@@ -583,185 +719,6 @@ general (GlobalGeneral)
   | directory, change the value to ``${CANONICAL_GAME_DIR}/plugins``.
   | **Type:** ``String``
   | **Default:** ``${CANONICAL_MODS_DIR}/plugins``
-  |
-
-.. _ConfigType_GlobalWorld:
-
-world (GlobalWorld)
--------------------
-
-* **auto-player-save-interval**
-
-  | The auto-save tick interval used when saving global player data. 
-  | **Note**: ``20`` ticks is equivalent to ``1`` second. Set to ``0`` to disable.
-  | **Type:** ``int``
-  | **Default:** ``900``
-  |
-
-* **auto-save-interval**
-
-  | The auto-save tick interval used to save all loaded chunks in a world. 
-  | Set to ``0`` to disable. 
-  | **Note**: ``20`` ticks is equivalent to ``1`` second.
-  | **Type:** ``int``
-  | **Default:** ``900``
-  |
-
-* **chunk-gc-load-threshold**
-
-  | The number of newly loaded chunks before triggering a forced cleanup. 
-  | **Note**: When triggered, the loaded chunk threshold will reset and start incrementing. 
-  | Disabled by default.
-  | **Type:** ``int``
-  | **Default:** ``0``
-  |
-
-* **chunk-gc-tick-interval**
-
-  | The tick interval used to cleanup all inactive chunks that have leaked in a world. 
-  | Set to ``0`` to disable which restores vanilla handling.
-  | **Type:** ``int``
-  | **Default:** ``600``
-  |
-
-* **chunk-unload-delay**
-
-  | The number of seconds to delay a chunk unload once marked inactive. 
-  | **Note**: This gets reset if the chunk becomes active again.
-  | **Type:** ``int``
-  | **Default:** ``15``
-  |
-
-* **deny-chunk-requests**
-
-  | If ``true``, any request for a chunk not currently loaded will be denied (exceptions apply 
-  | for things like world gen and player movement). 
-  | **Warning**: As this is an experimental setting for performance gain, if you encounter any issues 
-  | then we recommend disabling it.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **gameprofile-lookup-task-interval**
-
-  | The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. 
-  | **Note**: This setting should be raised if you experience the following error: 
-  | ``The client has sent too many requests within a certain amount of time``. 
-  | Finally, if set to ``0`` or less, the default interval will be used.
-  | **Type:** ``int``
-  | **Default:** ``4``
-  |
-
-* **generate-spawn-on-load**
-
-  | If ``true``, this world will generate its spawn the moment its loaded.
-  | **Type:** ``Boolean``
-  | **Default:** ``false``
-  |
-
-* **invalid-lookup-uuids**
-
-  | The list of uuid's that should never perform a lookup against Mojang's session server. 
-  | **Note**: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
-  | **Type:** ``List<UUID>``
-  |
-
-* **item-merge-radius**
-
-  | The defined merge radius for Item entities such that when two items are 
-  | within the defined radius of each other, they will attempt to merge. Usually, 
-  | the default radius is set to ``0.5`` in Vanilla, however, for performance reasons 
-  | ``2.5`` is generally acceptable. 
-  | **Note**: Increasing the radius higher will likely cause performance degradation 
-  | with larger amount of items as they attempt to merge and search nearby 
-  | areas for more items. Setting to a negative value is not supported!
-  | **Type:** ``double``
-  | **Default:** ``2.5``
-  |
-
-* **keep-spawn-loaded**
-
-  | If ``true``, this worlds spawn will remain loaded with no players.
-  | **Type:** ``Boolean``
-  | **Default:** ``true``
-  |
-
-* **leaf-decay**
-
-  | If ``true``, natural leaf decay is allowed.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **load-on-startup**
-
-  | If ``true``, this world will load on startup.
-  | **Type:** ``Boolean``
-  | **Default:** ``false``
-  |
-
-* **max-chunk-unloads-per-tick**
-
-  | The maximum number of queued unloaded chunks that will be unloaded in a single tick. 
-  | **Note**: With the chunk gc enabled, this setting only applies to the ticks 
-  | where the gc runs (controlled by ``chunk-gc-tick-interval``) 
-  | **Note**: If the maximum unloads is too low, too many chunks may remain 
-  | loaded on the world and increases the chance for a drop in tps.
-  | **Type:** ``int``
-  | **Default:** ``100``
-  |
-
-* **mob-spawn-range**
-
-  | Specifies the radius (in chunks) of where creatures will spawn. 
-  | This value is capped to the current view distance setting in server.properties
-  | **Type:** ``int``
-  | **Default:** ``4``
-  |
-
-* **portal-agents**
-
-  | A list of all detected portal agents used in this world. 
-  | In order to override, change the target world name to any other valid world. 
-  | **Note**: If world is not found, it will fallback to default.
-  | **Type:** ``Map<String, String>``
-  |
-
-* **pvp-enabled**
-
-  | If ``true``, this world will allow PVP combat.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **view-distance**
-
-  | Override world distance per world/dimension 
-  | The value must be greater than or equal to ``3`` and less than or equal to ``32`` 
-  | The server-wide view distance will be used when the value is ``-1``.
-  | **Type:** ``int``
-  | **Default:** ``-1``
-  |
-
-* **weather-ice-and-snow**
-
-  | If ``true``, natural formation of ice and snow in supported biomes will be allowed.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **weather-thunder**
-
-  | If ``true``, thunderstorms will be initiated in supported biomes.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **world-enabled**
-
-  | If ``true``, this world will be registered.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
   |
 
 .. _ConfigType_Logging:
@@ -1297,142 +1254,6 @@ permission (Permission)
   | **Default:** ``false``
   |
 
-.. _ConfigType_PhaseTracker:
-
-cause-tracker (PhaseTracker)
-----------------------------
-
-* **auto-fix-null-source-block-providing-tile-entities**
-
-  | A mapping that is semi-auto-populating for TileEntities whose types
-  | are found to be providing ``null`` Block sources as neighbor notifications
-  | that end up causing crashes or spam reports. If the value is set to 
-  | ``true``, then a ``workaround`` will be attempted. If not, the 
-  | current BlockState at the target source will be queried from the world.
-  | This map having a specific
-  | entry of a TileEntity will prevent a log or warning come up to any logs
-  | when that ``null`` arises, and Sponge will self-rectify the TileEntity
-  | by calling the method ``getBlockType()``. It is advised that if the mod
-  | id in question is coming up, that the mod author is notified about the
-  | error-prone usage of the field ``blockType``. You can refer them to
-  | the following links for the issue:
-  |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
-  |  https://github.com/SpongePowered/SpongeForge/issues/2787
-  | Also, please provide them with these links for the example PR to
-  | fix the issue itself, as the fix is very simple:
-  | https://github.com/TehNut/Soul-Shards-Respawn/pull/24
-  | https://github.com/Epoxide-Software/Enchanting-Plus/pull/135
-  | **Type:** ``Map<String, Boolean>``
-  |
-
-* **capture-async-spawning-entities**
-
-  | If set to ``true``, when a mod or plugin attempts to spawn an entity 
-  | off the main server thread, Sponge will automatically 
-  | capture said entity to spawn it properly on the main 
-  | server thread. The catch to this is that some mods are 
-  | not considering the consequences of spawning an entity 
-  | off the server thread, and are unaware of potential race 
-  | conditions they may cause. If this is set to false, 
-  | Sponge will politely ignore the entity being spawned, 
-  | and emit a warning about said spawn anyways.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **generate-stacktrace-per-phase**
-
-  | If ``true``, more thorough debugging for PhaseStates 
-  | such that a StackTrace is created every time a PhaseState 
-  | switches, allowing for more fine grained troubleshooting 
-  | in the cases of runaway phase states. Note that this is 
-  | not extremely performant and may have some associated costs 
-  | with generating the stack traces constantly.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **max-block-processing-depth**
-
-  | The maximum number of times to recursively process transactions in a single phase.
-  | Some mods may interact badly with Sponge's block capturing system, causing Sponge to
-  | end up capturing block transactions every time it tries to process an existing batch.
-  | Due to the recursive nature of the depth-first processing that Sponge uses to handle block transactions,
-  | this can result in a stack overflow, which causes us to lose all infomration about the original cause of the issue.
-  | To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds
-  | this threshold.
-  | The default value should almost always work properly -  it's unlikely you'll ever have to change it.
-  | **Type:** ``int``
-  | **Default:** ``1000``
-  |
-
-* **maximum-printed-runaway-counts**
-
-  | If verbose is not enabled, this restricts the amount of 
-  | runaway phase state printouts, usually happens on a server 
-  | where a PhaseState is not completing. Although rare, it should 
-  | never happen, but when it does, sometimes it can continuously print 
-  | more and more. This attempts to placate that while a fix can be worked on 
-  | to resolve the runaway. If verbose is enabled, they will always print.
-  | **Type:** ``int``
-  | **Default:** ``3``
-  |
-
-* **report-null-source-blocks-on-neighbor-notifications**
-
-  | If true, when a mod attempts to perform a neighbor notification
-  | on a block, some mods do not know to perform a ``null`` check
-  | on the source block of their TileEntity. This usually goes by
-  | unnoticed by other mods, because they may perform ``==`` instance
-  | equality checks instead of calling methods on the potentially
-  | null Block, but Sponge uses the block to build information to
-  | help tracking. This has caused issues in the past. Generally,
-  | this can be useful for leaving ``true`` so a proper report is
-  | generated once for your server, and can be reported to the
-  | offending mod author.
-  | This is ``false`` by default in SpongeVanilla.
-  | Review the following links for more info:
-  |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
-  |  https://github.com/SpongePowered/SpongeForge/issues/2787
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **resync-commands-from-async**
-
-  | If set to ``true``, when a mod or plugin attempts to submit a command
-  | asynchronously, Sponge will automatically capture said command
-  | and submit it for processing on the server thread. The catch to
-  | this is that some mods are performing these commands in vanilla
-  | without considering the possible consequences of such commands
-  | affecting any thread-unsafe parts of Minecraft, such as worlds,
-  | block edits, entity spawns, etc. If this is set to false, Sponge
-  | will politely ignore the command being executed, and emit a warning
-  | about said command anyways.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **verbose**
-
-  | If ``true``, the phase tracker will print out when there are too many phases 
-  | being entered, usually considered as an issue of phase re-entrance and 
-  | indicates an unexpected issue of tracking phases not to complete. 
-  | If this is not reported yet, please report to Sponge. If it has been 
-  | reported, you may disable this.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **verbose-errors**
-
-  | If ``true``, the phase tracker will dump extra information about the current phases 
-  | when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information 
-  | in the exception itself can normally be used to determine the cause of the issue
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
 .. _ConfigType_PlayerBlockTracker:
 
 player-block-tracker (PlayerBlockTracker)
@@ -1668,6 +1489,185 @@ timings (Timings)
 
   | **Type:** ``boolean``
   | **Default:** ``false``
+  |
+
+.. _ConfigType_GlobalWorld:
+
+world (GlobalWorld)
+-------------------
+
+* **auto-player-save-interval**
+
+  | The auto-save tick interval used when saving global player data. 
+  | **Note**: ``20`` ticks is equivalent to ``1`` second. Set to ``0`` to disable.
+  | **Type:** ``int``
+  | **Default:** ``900``
+  |
+
+* **auto-save-interval**
+
+  | The auto-save tick interval used to save all loaded chunks in a world. 
+  | Set to ``0`` to disable. 
+  | **Note**: ``20`` ticks is equivalent to ``1`` second.
+  | **Type:** ``int``
+  | **Default:** ``900``
+  |
+
+* **chunk-gc-load-threshold**
+
+  | The number of newly loaded chunks before triggering a forced cleanup. 
+  | **Note**: When triggered, the loaded chunk threshold will reset and start incrementing. 
+  | Disabled by default.
+  | **Type:** ``int``
+  | **Default:** ``0``
+  |
+
+* **chunk-gc-tick-interval**
+
+  | The tick interval used to cleanup all inactive chunks that have leaked in a world. 
+  | Set to ``0`` to disable which restores vanilla handling.
+  | **Type:** ``int``
+  | **Default:** ``600``
+  |
+
+* **chunk-unload-delay**
+
+  | The number of seconds to delay a chunk unload once marked inactive. 
+  | **Note**: This gets reset if the chunk becomes active again.
+  | **Type:** ``int``
+  | **Default:** ``15``
+  |
+
+* **deny-chunk-requests**
+
+  | If ``true``, any request for a chunk not currently loaded will be denied (exceptions apply 
+  | for things like world gen and player movement). 
+  | **Warning**: As this is an experimental setting for performance gain, if you encounter any issues 
+  | then we recommend disabling it.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **gameprofile-lookup-task-interval**
+
+  | The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. 
+  | **Note**: This setting should be raised if you experience the following error: 
+  | ``The client has sent too many requests within a certain amount of time``. 
+  | Finally, if set to ``0`` or less, the default interval will be used.
+  | **Type:** ``int``
+  | **Default:** ``4``
+  |
+
+* **generate-spawn-on-load**
+
+  | If ``true``, this world will generate its spawn the moment its loaded.
+  | **Type:** ``Boolean``
+  | **Default:** ``false``
+  |
+
+* **invalid-lookup-uuids**
+
+  | The list of uuid's that should never perform a lookup against Mojang's session server. 
+  | **Note**: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
+  | **Type:** ``List<UUID>``
+  |
+
+* **item-merge-radius**
+
+  | The defined merge radius for Item entities such that when two items are 
+  | within the defined radius of each other, they will attempt to merge. Usually, 
+  | the default radius is set to ``0.5`` in Vanilla, however, for performance reasons 
+  | ``2.5`` is generally acceptable. 
+  | **Note**: Increasing the radius higher will likely cause performance degradation 
+  | with larger amount of items as they attempt to merge and search nearby 
+  | areas for more items. Setting to a negative value is not supported!
+  | **Type:** ``double``
+  | **Default:** ``2.5``
+  |
+
+* **keep-spawn-loaded**
+
+  | If ``true``, this worlds spawn will remain loaded with no players.
+  | **Type:** ``Boolean``
+  | **Default:** ``true``
+  |
+
+* **leaf-decay**
+
+  | If ``true``, natural leaf decay is allowed.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **load-on-startup**
+
+  | If ``true``, this world will load on startup.
+  | **Type:** ``Boolean``
+  | **Default:** ``false``
+  |
+
+* **max-chunk-unloads-per-tick**
+
+  | The maximum number of queued unloaded chunks that will be unloaded in a single tick. 
+  | **Note**: With the chunk gc enabled, this setting only applies to the ticks 
+  | where the gc runs (controlled by ``chunk-gc-tick-interval``) 
+  | **Note**: If the maximum unloads is too low, too many chunks may remain 
+  | loaded on the world and increases the chance for a drop in tps.
+  | **Type:** ``int``
+  | **Default:** ``100``
+  |
+
+* **mob-spawn-range**
+
+  | Specifies the radius (in chunks) of where creatures will spawn. 
+  | This value is capped to the current view distance setting in server.properties
+  | **Type:** ``int``
+  | **Default:** ``4``
+  |
+
+* **portal-agents**
+
+  | A list of all detected portal agents used in this world. 
+  | In order to override, change the target world name to any other valid world. 
+  | **Note**: If world is not found, it will fallback to default.
+  | **Type:** ``Map<String, String>``
+  |
+
+* **pvp-enabled**
+
+  | If ``true``, this world will allow PVP combat.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **view-distance**
+
+  | Override world distance per world/dimension 
+  | The value must be greater than or equal to ``3`` and less than or equal to ``32`` 
+  | The server-wide view distance will be used when the value is ``-1``.
+  | **Type:** ``int``
+  | **Default:** ``-1``
+  |
+
+* **weather-ice-and-snow**
+
+  | If ``true``, natural formation of ice and snow in supported biomes will be allowed.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **weather-thunder**
+
+  | If ``true``, thunderstorms will be initiated in supported biomes.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **world-enabled**
+
+  | If ``true``, this world will be registered.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
   |
 
 

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -528,7 +528,7 @@ Exploit
   | such that the entity that does not ``belong`` in the saving
   | chunk will not be saved, and forced an update to the world's
   | tracked entity lists for chunks.
-  | See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0311``-Prevent-Saving-Bad-entities-to-chunks.patch
+  | See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0311-Prevent-Saving-Bad-entities-to-chunks.patch
   | **Type:** ``boolean``
   | **Default:** ``true``
   |
@@ -536,7 +536,7 @@ Exploit
 * **limit-book-size**
 
   | Limits the size of a book that can be sent by the client.
-  | See https://github.com/PaperMC/Paper/blob/f8058a8187da9f6185d95bb786783e12c79c8b18/Spigot-Server-Patches/``0403``-Book-Size-Limits.patch
+  | See https://github.com/PaperMC/Paper/blob/f8058a8187da9f6185d95bb786783e12c79c8b18/Spigot-Server-Patches/0403-Book-Size-Limits.patch
   | (Only affects SpongeVanilla)
   | **Type:** ``boolean``
   | **Default:** ``true``
@@ -549,7 +549,7 @@ Exploit
   | etc. can a position lead an entity to no longer exist
   | within it's currently marked and tracked chunk. This will
   | enable that chunk for the position is loaded. Part of several
-  | exploits.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0335``-Ensure-chunks-are-always-loaded-on-hard-position-set.patch
+  | exploits.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0335-Ensure-chunks-are-always-loaded-on-hard-position-set.patch
   | (Only affects SpongeVanilla)
   | **Type:** ``boolean``
   | **Default:** ``true``
@@ -559,7 +559,7 @@ Exploit
 
   | Enables forcing chunks to save when an entity is added
   | or removed from said chunk. This is a partial fix for
-  | some exploits using vehicles.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0306``-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch
+  | some exploits using vehicles.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0306-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch
   | (Only affects SpongeVanilla)
   | **Type:** ``boolean``
   | **Default:** ``true``
@@ -585,7 +585,7 @@ Exploit
   | Enables forcing updates to the player's location on vehicle movement.
   | This is partially required to update the server's understanding of
   | where the player exists, and allows chunk loading issues to be avoided
-  | with laggy connections and/or hack clients.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0378``-Sync-Player-Position-to-Vehicles.patch
+  | with laggy connections and/or hack clients.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0378-Sync-Player-Position-to-Vehicles.patch
   | (Only affects SpongeVanilla)
   | **Type:** ``boolean``
   | **Default:** ``true``
@@ -595,7 +595,7 @@ Exploit
 
   | Enables forcing a chunk-tracking refresh on entity movement.
   | This enables a guarantee that the entity is tracked in the 
-  | proper chunk when moving.https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0315``-Always-process-chunk-registration-after-moving.patch
+  | proper chunk when moving.https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch
   | (Only affects SpongeVanilla)
   | **Type:** ``boolean``
   | **Default:** ``true``
@@ -1174,7 +1174,7 @@ Optimization
   | little to no benefit to the client. Because of the nature of the
   | change, the default will be ``false`` due to the inability to pre-emptively
   | foretell whether mod compatibility will fail with these changes or not.
-  | Refer to: https://github.com/PaperMC/Paper/blob/8175ec916f31dcd130fe0884fe46bdc187d829aa/Spigot-Server-Patches/``0269``-Optimize-Hoppers.patch
+  | Refer to: https://github.com/PaperMC/Paper/blob/8175ec916f31dcd130fe0884fe46bdc187d829aa/Spigot-Server-Patches/0269-Optimize-Hoppers.patch
   | for more details.
   | **Type:** ``boolean``
   | **Default:** ``false``
@@ -1249,11 +1249,11 @@ PhaseTracker
   | error-prone usage of the field ``blockType``. You can refer them to
   | the following links for the issue:
   |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
-  |  https://github.com/SpongePowered/SpongeForge/issues/``2787``
+  |  https://github.com/SpongePowered/SpongeForge/issues/2787
   | Also, please provide them with these links for the example PR to
   | fix the issue itself, as the fix is very simple:
-  | https://github.com/TehNut/Soul-Shards-Respawn/pull/``24``
-  | https://github.com/Epoxide-Software/Enchanting-Plus/pull/``135``
+  | https://github.com/TehNut/Soul-Shards-Respawn/pull/24
+  | https://github.com/Epoxide-Software/Enchanting-Plus/pull/135
   | **Type:** ``Map<String, Boolean>``
   |
 
@@ -1325,7 +1325,7 @@ PhaseTracker
   | This is ``false`` by default in SpongeVanilla.
   | Review the following links for more info:
   |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
-  |  https://github.com/SpongePowered/SpongeForge/issues/``2787``
+  |  https://github.com/SpongePowered/SpongeForge/issues/2787
   | **Type:** ``boolean``
   | **Default:** ``true``
   |

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -108,6 +108,11 @@ GlobalConfig
   | **Type:** :ref:`Optimization<ConfigType_Optimization>`
   |
 
+* **permission**
+
+  | **Type:** :ref:`Permission<ConfigType_Permission>`
+  |
+
 * **player-block-tracker**
 
   | **Type:** :ref:`PlayerBlockTracker<ConfigType_PlayerBlockTracker>`
@@ -145,6 +150,12 @@ GlobalConfig
 * **world**
 
   | **Type:** :ref:`GlobalWorld<ConfigType_GlobalWorld>`
+  |
+
+* **world-generation-modifiers**
+
+  | World Generation Modifiers to apply to the world
+  | **Type:** ``List<String>``
   |
 
 .. _ConfigType_AsyncLighting:
@@ -240,11 +251,59 @@ Commands
   | **Type:** ``Map<String, String>``
   |
 
+* **command-hiding**
+
+  | Defines how Sponge should act when a user tries to access a command they do not have
+  | permission for
+  | **Type:** :ref:`CommandsHidden<ConfigType_CommandsHidden>`
+  |
+
+* **enforce-permission-checks-on-non-sponge-commands**
+
+  | Some mods may not trigger a permission check when running their command. Setting this to
+  | true will enforce a check of the Sponge provided permission (``<modid>.command.<commandname>``).
+  | Note that setting this to true may cause some commands that are generally accessible to all to
+  | require a permission to run.
+  | Setting this to true will enable greater control over whether a command will appear in
+  | tab completion and Sponge's help command.
+  | If you are not using a permissions plugin, it is highly recommended that this is set to false
+  | (as it is by default).
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
 * **multi-world-patches**
 
   | Patches the specified commands to respect the world of the sender instead of applying the 
   | changes on the all worlds.
   | **Type:** ``Map<String, Boolean>``
+  |
+
+.. _ConfigType_CommandsHidden:
+
+CommandsHidden
+==============
+
+| Defines how Sponge should act when a user tries to access a command they do not have
+| permission for
+|
+
+* **hide-on-discovery-attempt**
+
+  | If this is true, when a user tries to tab complete a command, or use ``/sponge which`` or 
+  | ``/sponge:help`` this prevents commands a user does not have permission for from being completed.
+  | Note that some commands may not show up during tab complete if a user does not have permission
+  | regardless of this setting.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **hide-on-execution-attempt**
+
+  | If this is true, when a user tries to use a command they don't have permission for, Sponge
+  | will act as if the command doesn't exist, rather than showing a no permissions message.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
   |
 
 .. _ConfigType_Debug:
@@ -268,30 +327,41 @@ Debug
   | **Default:** ``false``
   |
 
-* **dump-chunks-on-deadlock**
-
-  | Dump chunks in the event of a deadlock
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **dump-heap-on-deadlock**
-
-  | Dump the heap in the event of a deadlock
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **dump-threads-on-warn**
-
-  | Dump the server thread on deadlock warning
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
 * **thread-contention-monitoring**
 
   | If ``true``, Java's thread contention monitoring for thread dumps is enabled.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+.. _ConfigType_EigenRedstone:
+
+EigenRedstone
+=============
+
+| Uses theosib's redstone algorithms to completely overhaul the way redstone works.
+|
+
+* **enabled**
+
+  | If ``true``, uses theosib's redstone implementation which improves performance. 
+  | See https://bugs.mojang.com/browse/MC-``11193`` and 
+  |      https://bugs.mojang.com/browse/MC-``81098`` for more information. 
+  | **Note**: We cannot guarantee compatibility with mods. Use at your discretion.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **vanilla-decrement**
+
+  | If ``true``, restores the vanilla algorithm for computing wire power levels when powering off.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **vanilla-search**
+
+  | If ``true``, restores the vanilla algorithm for propagating redstone wire changes.
   | **Type:** ``boolean``
   | **Default:** ``false``
   |
@@ -355,13 +425,6 @@ Entity
   | Number of colliding entities in one spot before logging a warning. Set to ``0`` to disable
   | **Type:** ``int``
   | **Default:** ``200``
-  |
-
-* **count-warn-size**
-
-  | Number of entities in one dimension before logging a warning. Set to ``0`` to disable
-  | **Type:** ``int``
-  | **Default:** ``0``
   |
 
 * **entity-painting-respawn-delay**
@@ -432,12 +495,6 @@ EntityCollision
   | **Default:** ``false``
   |
 
-* **defaults**
-
-  | Default maximum collisions used for all entities/blocks unless overridden.
-  | **Type:** ``Map<String, Integer>``
-  |
-
 * **max-entities-within-aabb**
 
   | Maximum amount of entities any given entity or block can collide with. This improves 
@@ -458,6 +515,63 @@ EntityCollision
 Exploit
 =======
 
+* **book-size-total-multiplier**
+
+  | If limit-book-size is enabled, controls the multiplier applied to each book page size
+  | **Type:** ``double``
+  | **Default:** ``0.98``
+  |
+
+* **filter-invalid-entities-on-chunk-save**
+
+  | Enables filtering invalid entities when a chunk is being saved
+  | such that the entity that does not ``belong`` in the saving
+  | chunk will not be saved, and forced an update to the world's
+  | tracked entity lists for chunks.
+  | See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0311``-Prevent-Saving-Bad-entities-to-chunks.patch
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **limit-book-size**
+
+  | Limits the size of a book that can be sent by the client.
+  | See https://github.com/PaperMC/Paper/blob/f8058a8187da9f6185d95bb786783e12c79c8b18/Spigot-Server-Patches/``0403``-Book-Size-Limits.patch
+  | (Only affects SpongeVanilla)
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **load-chunk-on-position-set**
+
+  | Enables focing a chunk load when an entity position
+  | is set. Usually due to teleportation, vehicle movement
+  | etc. can a position lead an entity to no longer exist
+  | within it's currently marked and tracked chunk. This will
+  | enable that chunk for the position is loaded. Part of several
+  | exploits.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0335``-Ensure-chunks-are-always-loaded-on-hard-position-set.patch
+  | (Only affects SpongeVanilla)
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **mark-chunks-as-dirty-on-entity-list-modification**
+
+  | Enables forcing chunks to save when an entity is added
+  | or removed from said chunk. This is a partial fix for
+  | some exploits using vehicles.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0306``-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch
+  | (Only affects SpongeVanilla)
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **max-book-page-size**
+
+  | If limit-book-size is enabled, controls the maximum size of a book page
+  | **Type:** ``int``
+  | **Default:** ``2560``
+  |
+
 * **prevent-creative-itemstack-name-exploit**
 
   | Prevents an exploit in which the client sends a packet with the 
@@ -466,10 +580,23 @@ Exploit
   | **Default:** ``true``
   |
 
-* **prevent-sign-command-exploit**
+* **sync-player-positions-for-vehicle-movement**
 
-  | Prevents an exploit in which the client sends a packet to update a sign containing 
-  | commands from a player without permission.
+  | Enables forcing updates to the player's location on vehicle movement.
+  | This is partially required to update the server's understanding of
+  | where the player exists, and allows chunk loading issues to be avoided
+  | with laggy connections and/or hack clients.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0378``-Sync-Player-Position-to-Vehicles.patch
+  | (Only affects SpongeVanilla)
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **update-tracked-chunk-on-entity-move**
+
+  | Enables forcing a chunk-tracking refresh on entity movement.
+  | This enables a guarantee that the entity is tracked in the 
+  | proper chunk when moving.https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/``0315``-Always-process-chunk-registration-after-moving.patch
+  | (Only affects SpongeVanilla)
   | **Type:** ``boolean``
   | **Default:** ``true``
   |
@@ -484,20 +611,13 @@ GlobalGeneral
   | The directory for Sponge plugin configurations, relative to the  
   | execution root or specified as an absolute path. 
   | Note that the default: ``${CANONICAL_GAME_DIR}/config`` 
-  | is going to use the ``plugins`` directory in the root game directory. 
+  | is going to use the ``config`` directory in the root game directory. 
   | If you wish for plugin configs to reside within a child of the configuration 
   | directory, change the value to, for example, ``${CANONICAL_CONFIG_DIR}/sponge/plugins``. 
   | **Note**: It is not recommended to set this to ``${CANONICAL_CONFIG_DIR}/sponge``, as there is 
   | a possibility that plugin configurations can conflict the Sponge core configurations.
   | **Type:** ``String``
   | **Default:** ``${CANONICAL_GAME_DIR}/config``
-  |
-
-* **disable-warnings**
-
-  | Disable warning messages to server admins
-  | **Type:** ``boolean``
-  | **Default:** ``false``
   |
 
 * **file-io-thread-sleep**
@@ -576,25 +696,6 @@ GlobalWorld
   | **Default:** ``true``
   |
 
-* **flowing-lava-decay**
-
-  | Lava behaves like vanilla water when source block is removed
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **gameprofile-lookup-batch-size**
-
-  | The amount of GameProfile requests to make against Mojang's session server. 
-  | **Note**: Mojang accepts a maximum of ``600`` requests every ``10`` minutes from a single IP address. 
-  | If you are running multiple servers behind the same IP, it is recommended to raise the ``gameprofile-task-interval`` setting  
-  | in order to compensate for the amount requests being sent. 
-  | Finally, if set to ``0`` or less, the default batch size will be used. 
-  | For more information visit http://wiki.vg/Mojang_API
-  | **Type:** ``int``
-  | **Default:** ``1``
-  |
-
 * **gameprofile-lookup-task-interval**
 
   | The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. 
@@ -609,12 +710,6 @@ GlobalWorld
 
   | If ``true``, this world will generate its spawn the moment its loaded.
   | **Type:** ``Boolean``
-  |
-
-* **infinite-water-source**
-
-  | Vanilla water source behavior - is infinite
-  | **Type:** ``boolean``
   | **Default:** ``false``
   |
 
@@ -656,7 +751,7 @@ GlobalWorld
 
   | If ``true``, this world will load on startup.
   | **Type:** ``Boolean``
-  | **Default:** ``true``
+  | **Default:** ``false``
   |
 
 * **max-chunk-unloads-per-tick**
@@ -860,22 +955,25 @@ Logging
 Metrics
 =======
 
-* **default-permission**
+* **global-state**
 
-  | Determines whether plugins that are newly added are allowed to perform
-  | data/metric collection by default. Plugins detected by Sponge will be added to the ``plugin-permissions`` section with this value.
-  | Set to true to enable metric gathering by default, false otherwise.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
+  | The global collection state that should be respected by all plugins that have no specified collection state. If undefined then it is treated as disabled.
+  | **Type:** ``Tristate``
+  | **Possible values:** 
+  | - ``TRUE``
+  | - ``FALSE``
+  | - ``UNDEFINED``
+  | **Default:** ``UNDEFINED``
   |
 
-* **plugin-permissions**
+* **plugin-states**
 
-  | Provides (or revokes) permission for metric gathering on a per plugin basis.
-  | Entries should be in the format ``plugin-id=<true|false>``.
-  | Deleting an entry from this list will reset it to the default specified in
-  | ``default-permission``
-  | **Type:** ``Map<String, Boolean>``
+  | Plugin-specific collection states that override the global collection state.
+  | **Type:** ``Map<String, Tristate>``
+  | **Possible values:** 
+  | - ``TRUE``
+  | - ``FALSE``
+  | - ``UNDEFINED``
   |
 
 .. _ConfigType_Module:
@@ -910,6 +1008,10 @@ Module
 
 * **exploits**
 
+  | Controls whether any exploit patches are applied.
+  | If there are issues with any specific exploits, please
+  | test in the exploit category first, before disabling all
+  | exploits with this toggle.
   | **Type:** ``boolean``
   | **Default:** ``true``
   |
@@ -999,6 +1101,18 @@ Optimization
   | **Default:** ``true``
   |
 
+* **disable-failing-deserialization-log-spam**
+
+  | Occasionally, some built in advancements, 
+  | recipes, etc. can fail to deserialize properly
+  | which ends up potentially spamming the server log
+  | and the original provider of the failing content
+  | is not able to fix. This provides an option to
+  | suppress the exceptions printing out in the log.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
 * **drops-pre-merge**
 
   | If ``true``, block item drops are pre-processed to avoid 
@@ -1009,6 +1123,12 @@ Optimization
   | without being merged.
   | **Type:** ``boolean``
   | **Default:** ``true``
+  |
+
+* **eigen-redstone**
+
+  | Uses theosib's redstone algorithms to completely overhaul the way redstone works.
+  | **Type:** :ref:`EigenRedstone<ConfigType_EigenRedstone>`
   |
 
 * **enchantment-helper-leak-fix**
@@ -1045,11 +1165,28 @@ Optimization
   | **Default:** ``true``
   |
 
+* **optimize-hoppers**
+
+  | Based on Aikar's optimizationo of Hoppers, setting this to ``true``
+  | will allow for hoppers to save performing server -> client updates
+  | when transferring items. Because hoppers can transfer items multiple
+  | times per tick, these updates can get costly on the server, with
+  | little to no benefit to the client. Because of the nature of the
+  | change, the default will be ``false`` due to the inability to pre-emptively
+  | foretell whether mod compatibility will fail with these changes or not.
+  | Refer to: https://github.com/PaperMC/Paper/blob/8175ec916f31dcd130fe0884fe46bdc187d829aa/Spigot-Server-Patches/``0269``-Optimize-Hoppers.patch
+  | for more details.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
 * **panda-redstone**
 
   | If ``true``, uses Panda4494's redstone implementation which improves performance. 
   | See https://bugs.mojang.com/browse/MC-``11193`` for more information. 
-  | **Note**: This optimization has a few issues which are explained in the bug report.
+  | **Note**: This optimization has a few issues which are explained in the bug report. 
+  | We strongly recommend using eigen redstone over this implementation as this will
+  | be removed in a future release.
   | **Type:** ``boolean``
   | **Default:** ``false``
   |
@@ -1064,10 +1201,61 @@ Optimization
   | **Type:** :ref:`StructureSave<ConfigType_StructureSave>`
   |
 
+* **use-active-chunks-for-collisions**
+
+  | Vanilla performs a lot of is area loaded checks during
+  | entity collision calculations with blocks, and because
+  | these calculations require fetching the chunks to see
+  | if they are loaded, before getting the block states
+  | from those chunks, there can be some small performance
+  | increase by checking the entity's owned active chunk
+  | it may currently reside in. Essentially, instead of
+  | asking the world if those chunks are loaded, the entity
+  | would know whether it's chunks are loaded and that neighbor's
+  | chunks are loaded.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+.. _ConfigType_Permission:
+
+Permission
+==========
+
+* **forge-permissions-handler**
+
+  | If ``true``, Sponge plugins will be used to handle permissions rather than any Forge mod
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
 .. _ConfigType_PhaseTracker:
 
 PhaseTracker
 ============
+
+* **auto-fix-null-source-block-providing-tile-entities**
+
+  | A mapping that is semi-auto-populating for TileEntities whose types
+  | are found to be providing ``null`` Block sources as neighbor notifications
+  | that end up causing crashes or spam reports. If the value is set to 
+  | ``true``, then a ``workaround`` will be attempted. If not, the 
+  | current BlockState at the target source will be queried from the world.
+  | This map having a specific
+  | entry of a TileEntity will prevent a log or warning come up to any logs
+  | when that ``null`` arises, and Sponge will self-rectify the TileEntity
+  | by calling the method ``getBlockType()``. It is advised that if the mod
+  | id in question is coming up, that the mod author is notified about the
+  | error-prone usage of the field ``blockType``. You can refer them to
+  | the following links for the issue:
+  |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
+  |  https://github.com/SpongePowered/SpongeForge/issues/``2787``
+  | Also, please provide them with these links for the example PR to
+  | fix the issue itself, as the fix is very simple:
+  | https://github.com/TehNut/Soul-Shards-Respawn/pull/``24``
+  | https://github.com/Epoxide-Software/Enchanting-Plus/pull/``135``
+  | **Type:** ``Map<String, Boolean>``
+  |
 
 * **capture-async-spawning-entities**
 
@@ -1107,7 +1295,7 @@ PhaseTracker
   | this threshold.
   | The default value should almost always work properly -  it's unlikely you'll ever have to change it.
   | **Type:** ``int``
-  | **Default:** ``100``
+  | **Default:** ``1000``
   |
 
 * **maximum-printed-runaway-counts**
@@ -1120,6 +1308,41 @@ PhaseTracker
   | to resolve the runaway. If verbose is enabled, they will always print.
   | **Type:** ``int``
   | **Default:** ``3``
+  |
+
+* **report-null-source-blocks-on-neighbor-notifications**
+
+  | If true, when a mod attempts to perform a neighbor notification
+  | on a block, some mods do not know to perform a ``null`` check
+  | on the source block of their TileEntity. This usually goes by
+  | unnoticed by other mods, because they may perform ``==`` instance
+  | equality checks instead of calling methods on the potentially
+  | null Block, but Sponge uses the block to build information to
+  | help tracking. This has caused issues in the past. Generally,
+  | this can be useful for leaving ``true`` so a proper report is
+  | generated once for your server, and can be reported to the
+  | offending mod author.
+  | This is ``false`` by default in SpongeVanilla.
+  | Review the following links for more info:
+  |  https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
+  |  https://github.com/SpongePowered/SpongeForge/issues/``2787``
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **resync-commands-from-async**
+
+  | If set to ``true``, when a mod or plugin attempts to submit a command
+  | asynchronously, Sponge will automatically capture said command
+  | and submit it for processing on the server thread. The catch to
+  | this is that some mods are performing these commands in vanilla
+  | without considering the possible consequences of such commands
+  | affecting any thread-unsafe parts of Minecraft, such as worlds,
+  | block edits, entity spawns, etc. If this is set to false, Sponge
+  | will politely ignore the command being executed, and emit a warning
+  | about said command anyways.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
   |
 
 * **verbose**
@@ -1214,9 +1437,9 @@ Spawner
 
 * **tick-rate-aquatic**
 
-  | The aquatic spawning tick rate. Default: ``400``
+  | The aquatic spawning tick rate. Default: ``1``
   | **Type:** ``int``
-  | **Default:** ``400``
+  | **Default:** ``1``
   |
 
 * **tick-rate-monster**
@@ -1250,13 +1473,20 @@ StructureMod
 
 * **enabled**
 
-  | If ``false``, this mod will never save its structures.
+  | If ``false``, this mod will never save its structures. This may
+  | break some mod functionalities when requesting to locate their
+  | structures in a World. If true, allows structures not overridden
+  | in the section below to be saved by default. If you wish to find
+  | a structure to prevent it being saved, enable ``auto-populate`` and
+  | restart the server/world instance.
   | **Type:** ``boolean``
   | **Default:** ``true``
   |
 
 * **structures**
 
+  | Per structure override. Having the value of ``false`` will prevent
+  | that specific named structure from saving.
   | **Type:** ``Map<String, Boolean>``
   |
 
@@ -1274,13 +1504,23 @@ StructureSave
 
 * **auto-populate**
 
-  | If ``true``, newly discovered structures will be added to this config with a default value.
+  | If ``true``, newly discovered structures will be added to this config
+  | with a default value of ``true``. This is useful for finding out
+  | potentially what structures are being saved from various mods, and
+  | allowing those structures to be selectively disabled.
   | **Type:** ``boolean``
   | **Default:** ``false``
   |
 
 * **enabled**
 
+  | If ``false``, disables the modification to prevent certain structures
+  | from saving to the world's data folder. If you wish to prevent certain
+  | structures from saving, leave this ``enabled=true``. When ``true``, the
+  | modification allows for specific ``named`` structures to NOT be saved to
+  | disk. Examples of some structures that are costly and somewhat irrelivent
+  | is 'mineshaft's, as they build several structures and save, even after
+  | finished generating.
   | **Type:** ``boolean``
   | **Default:** ``false``
   |
@@ -1433,19 +1673,18 @@ Timings
 
 ------------------------------------------------------------------------------------------------------------
 
-This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 with Forge 2768), SpongeAPI version 7.1:
+This configuration file was generated using SpongeForge 7.1.9 (Forge 2838, SpongeAPI 7.1):
 
 .. code-block:: guess
 
-    # 1.0
-    #
+        # 1.0
+    # 
     # # If you need help with the configuration or have any questions related to Sponge,
-    # # join us at the IRC, Discord, or drop by our forums and leave a post.
-    #
+    # # join us at the IRC or drop by our forums and leave a post.
+    # 
     # # IRC: #sponge @ irc.esper.net ( https://webchat.esper.net/?channel=sponge )
-    # # Discord: (https://discord.gg/sponge)
     # # Forums: https://forums.spongepowered.org/
-    #
+    # 
 
     sponge {
         # Stopgap measures for dealing with broken mods
@@ -1460,21 +1699,42 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             ip-forwarding=false
         }
         cause-tracker {
-            # If set to 'true', when a mod or plugin attempts to spawn an entity
-            # off the main server thread, Sponge will automatically
-            # capture said entity to spawn it properly on the main
-            # server thread. The catch to this is that some mods are
-            # not considering the consequences of spawning an entity
-            # off the server thread, and are unaware of potential race
-            # conditions they may cause. If this is set to false,
-            # Sponge will politely ignore the entity being spawned,
+            # A mapping that is semi-auto-populating for TileEntities whose types
+            # are found to be providing "null" Block sources as neighbor notifications
+            # that end up causing crashes or spam reports. If the value is set to 
+            # "true", then a "workaround" will be attempted. If not, the 
+            # 
+            # current BlockState at the target source will be queried from the world.
+            # This map having a specific
+            # entry of a TileEntity will prevent a log or warning come up to any logs
+            # when that "null" arises, and Sponge will self-rectify the TileEntity
+            # by calling the method "getBlockType()". It is advised that if the mod
+            # id in question is coming up, that the mod author is notified about the
+            # error-prone usage of the field "blockType". You can refer them to
+            # the following links for the issue:
+            # https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
+            # https://github.com/SpongePowered/SpongeForge/issues/2787
+            # Also, please provide them with these links for the example PR to
+            # fix the issue itself, as the fix is very simple:
+            # https://github.com/TehNut/Soul-Shards-Respawn/pull/24
+            # https://github.com/Epoxide-Software/Enchanting-Plus/pull/135
+            # 
+            auto-fix-null-source-block-providing-tile-entities {}
+            # If set to 'true', when a mod or plugin attempts to spawn an entity 
+            # off the main server thread, Sponge will automatically 
+            # capture said entity to spawn it properly on the main 
+            # server thread. The catch to this is that some mods are 
+            # not considering the consequences of spawning an entity 
+            # off the server thread, and are unaware of potential race 
+            # conditions they may cause. If this is set to false, 
+            # Sponge will politely ignore the entity being spawned, 
             # and emit a warning about said spawn anyways.
             capture-async-spawning-entities=true
-            # If 'true', more thorough debugging for PhaseStates
-            # such that a StackTrace is created every time a PhaseState
-            # switches, allowing for more fine grained troubleshooting
-            # in the cases of runaway phase states. Note that this is
-            # not extremely performant and may have some associated costs
+            # If 'true', more thorough debugging for PhaseStates 
+            # such that a StackTrace is created every time a PhaseState 
+            # switches, allowing for more fine grained troubleshooting 
+            # in the cases of runaway phase states. Note that this is 
+            # not extremely performant and may have some associated costs 
             # with generating the stack traces constantly.
             generate-stacktrace-per-phase=false
             # The maximum number of times to recursively process transactions in a single phase.
@@ -1485,54 +1745,98 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             # To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds
             # this threshold.
             # The default value should almost always work properly -  it's unlikely you'll ever have to change it.
-            max-block-processing-depth=100
-            # If verbose is not enabled, this restricts the amount of
-            # runaway phase state printouts, usually happens on a server
-            # where a PhaseState is not completing. Although rare, it should
-            # never happen, but when it does, sometimes it can continuously print
-            # more and more. This attempts to placate that while a fix can be worked on
+            max-block-processing-depth=1000
+            # If verbose is not enabled, this restricts the amount of 
+            # runaway phase state printouts, usually happens on a server 
+            # where a PhaseState is not completing. Although rare, it should 
+            # never happen, but when it does, sometimes it can continuously print 
+            # more and more. This attempts to placate that while a fix can be worked on 
             # to resolve the runaway. If verbose is enabled, they will always print.
             maximum-printed-runaway-counts=3
-            # If 'true', the phase tracker will print out when there are too many phases
-            # being entered, usually considered as an issue of phase re-entrance and
-            # indicates an unexpected issue of tracking phases not to complete.
-            # If this is not reported yet, please report to Sponge. If it has been
+            # If true, when a mod attempts to perform a neighbor notification
+            # on a block, some mods do not know to perform a 'null' check
+            # on the source block of their TileEntity. This usually goes by
+            # unnoticed by other mods, because they may perform '==' instance
+            # equality checks instead of calling methods on the potentially
+            # null Block, but Sponge uses the block to build information to
+            # help tracking. This has caused issues in the past. Generally,
+            # this can be useful for leaving "true" so a proper report is
+            # generated once for your server, and can be reported to the
+            # offending mod author.
+            # This is 'false' by default in SpongeVanilla.
+            # Review the following links for more info:
+            # https://gist.github.com/gabizou/ad570dc09dfed259cac9d74284e78e8b
+            # https://github.com/SpongePowered/SpongeForge/issues/2787
+            # 
+            report-null-source-blocks-on-neighbor-notifications=false
+            # If set to 'true', when a mod or plugin attempts to submit a command
+            # asynchronously, Sponge will automatically capture said command
+            # and submit it for processing on the server thread. The catch to
+            # this is that some mods are performing these commands in vanilla
+            # without considering the possible consequences of such commands
+            # affecting any thread-unsafe parts of Minecraft, such as worlds,
+            # block edits, entity spawns, etc. If this is set to false, Sponge
+            # will politely ignore the command being executed, and emit a warning
+            # about said command anyways.
+            resync-commands-from-async=true
+            # If 'true', the phase tracker will print out when there are too many phases 
+            # being entered, usually considered as an issue of phase re-entrance and 
+            # indicates an unexpected issue of tracking phases not to complete. 
+            # If this is not reported yet, please report to Sponge. If it has been 
             # reported, you may disable this.
             verbose=true
-            # If 'true', the phase tracker will dump extra information about the current phases
-            # when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information
+            # If 'true', the phase tracker will dump extra information about the current phases 
+            # when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information 
             # in the exception itself can normally be used to determine the cause of the issue
             verbose-errors=false
         }
         commands {
-            # Command aliases will resolve conflicts when multiple plugins request a specific command,
+            # Command aliases will resolve conflicts when multiple plugins request a specific command, 
             # Correct syntax is <unqualified command>=<plugin name> e.g. "sethome=homeplugin"
             aliases {}
-            # Patches the specified commands to respect the world of the sender instead of applying the
+            # Defines how Sponge should act when a user tries to access a command they do not have
+            # permission for
+            command-hiding {
+                # If this is true, when a user tries to tab complete a command, or use "/sponge which" or 
+                # "/sponge:help" this prevents commands a user does not have permission for from being completed.
+                # 
+                # Note that some commands may not show up during tab complete if a user does not have permission
+                # regardless of this setting.
+                hide-on-discovery-attempt=true
+                # If this is true, when a user tries to use a command they don't have permission for, Sponge
+                # will act as if the command doesn't exist, rather than showing a no permissions message.
+                hide-on-execution-attempt=false
+            }
+            # Some mods may not trigger a permission check when running their command. Setting this to
+            # true will enforce a check of the Sponge provided permission ("<modid>.command.<commandname>").
+            # Note that setting this to true may cause some commands that are generally accessible to all to
+            # require a permission to run.
+            # 
+            # Setting this to true will enable greater control over whether a command will appear in
+            # tab completion and Sponge's help command.
+            # 
+            # If you are not using a permissions plugin, it is highly recommended that this is set to false
+            # (as it is by default).
+            enforce-permission-checks-on-non-sponge-commands=false
+            # Patches the specified commands to respect the world of the sender instead of applying the 
             # changes on the all worlds.
-            multi-world-patches {}
+            multi-world-patches {
+                ""=true
+            }
         }
         debug {
             # Detect and prevent parts of PlayerChunkMap being called off the main thread.
             # This may decrease sever preformance, so you should only enable it when debugging a specific issue.
             concurrent-chunk-map-checks=false
-            # Detect and prevent certain attempts to use entities concurrently.
+            # Detect and prevent certain attempts to use entities concurrently. 
             # WARNING: May drastically decrease server performance. Only set this to 'true' to debug a pre-existing issue.
             concurrent-entity-checks=false
-            # Dump chunks in the event of a deadlock
-            dump-chunks-on-deadlock=false
-            # Dump the heap in the event of a deadlock
-            dump-heap-on-deadlock=false
-            # Dump the server thread on deadlock warning
-            dump-threads-on-warn=false
             # If 'true', Java's thread contention monitoring for thread dumps is enabled.
             thread-contention-monitoring=false
         }
         entity {
             # Number of colliding entities in one spot before logging a warning. Set to 0 to disable
             collision-warn-size=200
-            # Number of entities in one dimension before logging a warning. Set to 0 to disable
-            count-warn-size=0
             # Number of ticks before a painting is respawned on clients when their art is changed
             entity-painting-respawn-delay=2
             # Number of ticks before the fake player entry of a human is removed from the tab list (range of 0 to 100 ticks).
@@ -1567,13 +1871,8 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
         entity-collisions {
             # If 'true', newly discovered entities/blocks will be added to this config with a default value.
             auto-populate=false
-            # Default maximum collisions used for all entities/blocks unless overridden.
-            defaults {
-                blocks=8
-                entities=8
-            }
-            # Maximum amount of entities any given entity or block can collide with. This improves
-            # performance when there are more than 8 entities on top of each other such as a 1x1
+            # Maximum amount of entities any given entity or block can collide with. This improves 
+            # performance when there are more than 8 entities on top of each other such as a 1x1 
             # spawn pen. Set to 0 to disable.
             max-entities-within-aabb=8
             # Per-mod overrides. Refer to the minecraft default mod for example.
@@ -1585,8 +1884,8 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
                     # If 'false', entity collision rules for this mod will be ignored.
                     enabled=true
                     entities {
-                        botaniacorporeaspark=-1
-                        botaniaspark=-1
+                        corporeaspark=-1
+                        spark=-1
                     }
                 }
                 minecraft {
@@ -1620,6 +1919,7 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             filter-invalid-entities-on-chunk-save=true
             # Limits the size of a book that can be sent by the client.
             # See https://github.com/PaperMC/Paper/blob/f8058a8187da9f6185d95bb786783e12c79c8b18/Spigot-Server-Patches/0403-Book-Size-Limits.patch
+            # (Only affects SpongeVanilla)
             limit-book-size=true
             # Enables focing a chunk load when an entity position
             # is set. Usually due to teleportation, vehicle movement
@@ -1627,46 +1927,48 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             # within it's currently marked and tracked chunk. This will
             # enable that chunk for the position is loaded. Part of several
             # exploits.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0335-Ensure-chunks-are-always-loaded-on-hard-position-set.patch
+            # (Only affects SpongeVanilla)
             load-chunk-on-position-set=true
             # Enables forcing chunks to save when an entity is added
             # or removed from said chunk. This is a partial fix for
             # some exploits using vehicles.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0306-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch
+            # (Only affects SpongeVanilla)
             mark-chunks-as-dirty-on-entity-list-modification=true
             # If limit-book-size is enabled, controls the maximum size of a book page
             max-book-page-size=2560
-            # Prevents an exploit in which the client sends a packet with the
+            # Prevents an exploit in which the client sends a packet with the 
             # itemstack name exceeding the string limit.
             prevent-creative-itemstack-name-exploit=true
             # Enables forcing updates to the player's location on vehicle movement.
             # This is partially required to update the server's understanding of
             # where the player exists, and allows chunk loading issues to be avoided
             # with laggy connections and/or hack clients.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0378-Sync-Player-Position-to-Vehicles.patch
+            # (Only affects SpongeVanilla)
             sync-player-positions-for-vehicle-movement=true
             # Enables forcing a chunk-tracking refresh on entity movement.
-            # This enables a guarantee that the entity is tracked in the
+            # This enables a guarantee that the entity is tracked in the 
             # proper chunk when moving.https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch
+            # (Only affects SpongeVanilla)
             update-tracked-chunk-on-entity-move=true
         }
         general {
-            # The directory for Sponge plugin configurations, relative to the
-            # execution root or specified as an absolute path.
-            # Note that the default: "${CANONICAL_GAME_DIR}/config"
-            # is going to use the "plugins" directory in the root game directory.
-            # If you wish for plugin configs to reside within a child of the configuration
-            # directory, change the value to, for example, "${CANONICAL_CONFIG_DIR}/sponge/plugins".
-            # Note: It is not recommended to set this to "${CANONICAL_CONFIG_DIR}/sponge", as there is
-            # a possibility that plugin configurations can conflict the Sponge core configurations.
-            #
+            # The directory for Sponge plugin configurations, relative to the  
+            # execution root or specified as an absolute path. 
+            # Note that the default: "${CANONICAL_GAME_DIR}/config" 
+            # is going to use the "config" directory in the root game directory. 
+            # If you wish for plugin configs to reside within a child of the configuration 
+            # directory, change the value to, for example, "${CANONICAL_CONFIG_DIR}/sponge/plugins". 
+            # Note: It is not recommended to set this to "${CANONICAL_CONFIG_DIR}/sponge", as there is 
+            # a possibility that plugin configurations can conflict the Sponge core configurations. 
+            # 
             config-dir="${CANONICAL_GAME_DIR}/config"
-            # Disable warning messages to server admins
-            disable-warnings=false
             # If 'true', sleeping between chunk saves will be enabled, beware of memory issues.
             file-io-thread-sleep=false
-            # Additional directory to search for plugins, relative to the
-            # execution root or specified as an absolute path.
-            # Note that the default: "${CANONICAL_MODS_DIR}/plugins"
-            # is going to search for a plugins folder in the mods directory.
-            # If you wish for the plugins folder to reside in the root game
+            # Additional directory to search for plugins, relative to the 
+            # execution root or specified as an absolute path. 
+            # Note that the default: "${CANONICAL_MODS_DIR}/plugins" 
+            # is going to search for a plugins folder in the mods directory. 
+            # If you wish for the plugins folder to reside in the root game 
             # directory, change the value to "${CANONICAL_GAME_DIR}/plugins".
             plugins-dir="${CANONICAL_MODS_DIR}/plugins"
         }
@@ -1710,19 +2012,10 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             world-auto-save=false
         }
         metrics {
-            # Determines whether plugins that are newly added are allowed to perform
-            # data/metric collection by default. Plugins detected by Sponge will be added to the "plugin-permissions" section with this value.
-            #
-            # Set to true to enable metric gathering by default, false otherwise.
-            default-permission=false
-            # Provides (or revokes) permission for metric gathering on a per plugin basis.
-            # Entries should be in the format "plugin-id=<true|false>".
-            #
-            # Deleting an entry from this list will reset it to the default specified in
-            # "default-permission"
-            plugin-permissions {
-                docsconfiglister=false
-            }
+            # The global collection state that should be respected by all plugins that have no specified collection state. If undefined then it is treated as disabled.
+            global-state=UNDEFINED
+            # Plugin-specific collection states that override the global collection state.
+            plugin-states {}
         }
         modules {
             # Enables experimental fixes for broken mods
@@ -1740,7 +2033,7 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             optimizations=true
             # Use real (wall) time instead of ticks as much as possible
             realtime=false
-            # Controls block range and tick rate of tileentities.
+            # Controls block range and tick rate of tileentities. 
             # Use with caution as this can break intended functionality.
             tileentity-activation=false
             timings=true
@@ -1762,16 +2055,35 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
                 # The amount of threads to dedicate for asynchronous lighting updates. (Default: 2)
                 num-threads=2
             }
-            # Caches tameable entities owners to avoid constant lookups against data watchers. If mods
+            # Caches tameable entities owners to avoid constant lookups against data watchers. If mods 
             # cause issues, disable this.
             cache-tameable-owners=true
-            # If 'true', block item drops are pre-processed to avoid
-            # having to spawn extra entities that will be merged post spawning.
-            # Usually, Sponge is smart enough to determine when to attempt an item pre-merge
-            # and when not to, however, in certain cases, some mods rely on items not being
-            # pre-merged and actually spawned, in which case, the items will flow right through
+            # Occasionally, some built in advancements, 
+            # recipes, etc. can fail to deserialize properly
+            # which ends up potentially spamming the server log
+            # and the original provider of the failing content
+            # is not able to fix. This provides an option to
+            # suppress the exceptions printing out in the log.
+            disable-failing-deserialization-log-spam=true
+            # If 'true', block item drops are pre-processed to avoid 
+            # having to spawn extra entities that will be merged post spawning. 
+            # Usually, Sponge is smart enough to determine when to attempt an item pre-merge 
+            # and when not to, however, in certain cases, some mods rely on items not being 
+            # pre-merged and actually spawned, in which case, the items will flow right through 
             # without being merged.
             drops-pre-merge=false
+            # Uses theosib's redstone algorithms to completely overhaul the way redstone works.
+            eigen-redstone {
+                # If 'true', uses theosib's redstone implementation which improves performance. 
+                # See https://bugs.mojang.com/browse/MC-11193 and 
+                #     https://bugs.mojang.com/browse/MC-81098 for more information. 
+                # Note: We cannot guarantee compatibility with mods. Use at your discretion.
+                enabled=false
+                # If 'true', restores the vanilla algorithm for computing wire power levels when powering off.
+                vanilla-decrement=false
+                # If 'true', restores the vanilla algorithm for propagating redstone wire changes.
+                vanilla-search=false
+            }
             # If 'true', provides a fix for possible leaks through
             # Minecraft's enchantment helper code that can leak
             # entity and world references without much interaction
@@ -1781,7 +2093,7 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             # have any of the patch, leading to the recommendation that this
             # patch is enabled "for sure" when using SpongeVanilla implementation.
             # See https://bugs.mojang.com/browse/MC-128547 for more information.
-            #
+            # 
             enchantment-helper-leak-fix=true
             # If 'true', allows for Sponge to make better assumptinos on single threaded
             # operations with relation to various checks for server threaded operations.
@@ -1792,39 +2104,83 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             # If 'true', re-writes the incredibly inefficient Vanilla Map code.
             # This yields enormous performance enhancements when using many maps, but has a tiny chance of breaking mods that invasively modify Vanilla.It is strongly reccomended to keep this on, unless explicitly advised otherwise by a Sponge developer
             map-optimization=true
-            # If 'true', uses Panda4494's redstone implementation which improves performance.
-            # See https://bugs.mojang.com/browse/MC-11193 for more information.
-            # Note: This optimization has a few issues which are explained in the bug report.
+            # Based on Aikar's optimizationo of Hoppers, setting this to 'true'
+            # will allow for hoppers to save performing server -> client updates
+            # when transferring items. Because hoppers can transfer items multiple
+            # times per tick, these updates can get costly on the server, with
+            # little to no benefit to the client. Because of the nature of the
+            # change, the default will be 'false' due to the inability to pre-emptively
+            # foretell whether mod compatibility will fail with these changes or not.
+            # Refer to: https://github.com/PaperMC/Paper/blob/8175ec916f31dcd130fe0884fe46bdc187d829aa/Spigot-Server-Patches/0269-Optimize-Hoppers.patch
+            # for more details.
+            optimize-hoppers=false
+            # If 'true', uses Panda4494's redstone implementation which improves performance. 
+            # See https://bugs.mojang.com/browse/MC-11193 for more information. 
+            # Note: This optimization has a few issues which are explained in the bug report. 
+            # We strongly recommend using eigen redstone over this implementation as this will
+            # be removed in a future release.
             panda-redstone=false
-            # Handles structures that are saved to disk. Certain structures can take up large amounts
-            # of disk space for very large maps and the data for these structures is only needed while the
-            # world around them is generating. Disabling saving of these structures can save disk space and
-            # time during saves if your world is already fully generated.
+            # Handles structures that are saved to disk. Certain structures can take up large amounts 
+            # of disk space for very large maps and the data for these structures is only needed while the 
+            # world around them is generating. Disabling saving of these structures can save disk space and 
+            # time during saves if your world is already fully generated. 
             # Warning: disabling structure saving will break the vanilla locate command.
             structure-saving {
-                # If 'true', newly discovered structures will be added to this config with a default value.
+                # If 'true', newly discovered structures will be added to this config
+                # with a default value of 'true'. This is useful for finding out
+                # potentially what structures are being saved from various mods, and
+                # allowing those structures to be selectively disabled.
                 auto-populate=false
+                # If 'false', disables the modification to prevent certain structures
+                # from saving to the world's data folder. If you wish to prevent certain
+                # structures from saving, leave this "enabled=true". When 'true', the
+                # modification allows for specific 'named' structures to NOT be saved to
+                # disk. Examples of some structures that are costly and somewhat irrelivent
+                # is 'mineshaft's, as they build several structures and save, even after
+                # finished generating.
                 enabled=false
                 # Per-mod overrides. Refer to the minecraft default mod for example.
                 mods {
                     minecraft {
-                        # If 'false', this mod will never save its structures.
+                        # If 'false', this mod will never save its structures. This may
+                        # break some mod functionalities when requesting to locate their
+                        # structures in a World. If true, allows structures not overridden
+                        # in the section below to be saved by default. If you wish to find
+                        # a structure to prevent it being saved, enable 'auto-populate' and
+                        # restart the server/world instance.
                         enabled=true
+                        # Per structure override. Having the value of 'false' will prevent
+                        # that specific named structure from saving.
                         structures {
                             mineshaft=false
                         }
                     }
                 }
             }
+            # Vanilla performs a lot of is area loaded checks during
+            # entity collision calculations with blocks, and because
+            # these calculations require fetching the chunks to see
+            # if they are loaded, before getting the block states
+            # from those chunks, there can be some small performance
+            # increase by checking the entity's owned active chunk
+            # it may currently reside in. Essentially, instead of
+            # asking the world if those chunks are loaded, the entity
+            # would know whether it's chunks are loaded and that neighbor's
+            # chunks are loaded.
+            use-active-chunks-for-collisions=false
+        }
+        permission {
+            # If 'true', Sponge plugins will be used to handle permissions rather than any Forge mod
+            forge-permissions-handler=false
         }
         player-block-tracker {
             # Block IDs that will be blacklisted for player block placement tracking.
             block-blacklist=[]
-            # If 'true', adds player tracking support for block positions.
+            # If 'true', adds player tracking support for block positions. 
             # Note: This should only be disabled if you do not care who caused a block to change.
             enabled=true
         }
-        # Used to control spawn limits around players.
+        # Used to control spawn limits around players. 
         # Note: The radius uses the lower value of mob spawn range and server's view distance.
         spawner {
             # The number of ambients the spawner can potentially spawn around a player.
@@ -1839,8 +2195,8 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             tick-rate-ambient=400
             # The animal spawning tick rate. Default: 400
             tick-rate-animal=400
-            # The aquatic spawning tick rate. Default: 400
-            tick-rate-aquatic=400
+            # The aquatic spawning tick rate. Default: 1
+            tick-rate-aquatic=1
             # The monster spawning tick rate. Default: 1
             tick-rate-monster=1
         }
@@ -1851,15 +2207,15 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
         }
         # Blocks to blacklist for safe teleportation.
         teleport-helper {
-            # If 'true', this blacklist will always be respected, otherwise, plugins can choose whether
+            # If 'true', this blacklist will always be respected, otherwise, plugins can choose whether 
             # or not to respect it.
             force-blacklist=false
-            # Block IDs that are listed here will not be selected by Sponge's safe teleport routine as
-            # a safe block for players to warp into.
-            # You should only list blocks here that are incorrectly selected, solid blocks that prevent
+            # Block IDs that are listed here will not be selected by Sponge's safe teleport routine as 
+            # a safe block for players to warp into. 
+            # You should only list blocks here that are incorrectly selected, solid blocks that prevent 
             # movement are automatically excluded.
             unsafe-body-block-ids=[]
-            # Block IDs that are listed here will not be selected by Sponge's safe
+            # Block IDs that are listed here will not be selected by Sponge's safe 
             # teleport routine as a safe floor block.
             unsafe-floor-block-ids=[]
         }
@@ -1884,59 +2240,48 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             verbose=false
         }
         world {
-            # The auto-save tick interval used when saving global player data. (Default: 900)
+            # The auto-save tick interval used when saving global player data. (Default: 900) 
             # Note: 20 ticks is equivalent to 1 second. Set to 0 to disable.
             auto-player-save-interval=900
-            # The auto-save tick interval used to save all loaded chunks in a world.
-            # Set to 0 to disable. (Default: 900)
+            # The auto-save tick interval used to save all loaded chunks in a world. 
+            # Set to 0 to disable. (Default: 900) 
             # Note: 20 ticks is equivalent to 1 second.
             auto-save-interval=900
-            # The number of newly loaded chunks before triggering a forced cleanup.
-            # Note: When triggered, the loaded chunk threshold will reset and start incrementing.
+            # The number of newly loaded chunks before triggering a forced cleanup. 
+            # Note: When triggered, the loaded chunk threshold will reset and start incrementing. 
             # Disabled by default.
             chunk-gc-load-threshold=0
-            # The tick interval used to cleanup all inactive chunks that have leaked in a world.
+            # The tick interval used to cleanup all inactive chunks that have leaked in a world. 
             # Set to 0 to disable which restores vanilla handling. (Default: 600)
             chunk-gc-tick-interval=600
-            # The number of seconds to delay a chunk unload once marked inactive. (Default: 15)
+            # The number of seconds to delay a chunk unload once marked inactive. (Default: 15) 
             # Note: This gets reset if the chunk becomes active again.
             chunk-unload-delay=15
-            # If 'true', any request for a chunk not currently loaded will be denied (exceptions apply
-            # for things like world gen and player movement).
-            # Warning: As this is an experimental setting for performance gain, if you encounter any issues
+            # If 'true', any request for a chunk not currently loaded will be denied (exceptions apply 
+            # for things like world gen and player movement). 
+            # Warning: As this is an experimental setting for performance gain, if you encounter any issues 
             # then we recommend disabling it.
             deny-chunk-requests=false
-            # Lava behaves like vanilla water when source block is removed
-            flowing-lava-decay=false
-            # The amount of GameProfile requests to make against Mojang's session server. (Default: 1)
-            # Note: Mojang accepts a maximum of 600 requests every 10 minutes from a single IP address.
-            # If you are running multiple servers behind the same IP, it is recommended to raise the 'gameprofile-task-interval' setting
-            # in order to compensate for the amount requests being sent.
-            # Finally, if set to 0 or less, the default batch size will be used.
-            # For more information visit https://wiki.vg/Mojang_API
-            gameprofile-lookup-batch-size=1
-            # The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. (Default: 4)
-            # Note: This setting should be raised if you experience the following error:
-            # "The client has sent too many requests within a certain amount of time".
+            # The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. (Default: 4) 
+            # Note: This setting should be raised if you experience the following error: 
+            # "The client has sent too many requests within a certain amount of time". 
             # Finally, if set to 0 or less, the default interval will be used.
             gameprofile-lookup-task-interval=4
             # If 'true', this world will generate its spawn the moment its loaded.
             generate-spawn-on-load=false
-            # Vanilla water source behavior - is infinite
-            infinite-water-source=false
-            # The list of uuid's that should never perform a lookup against Mojang's session server.
+            # The list of uuid's that should never perform a lookup against Mojang's session server. 
             # Note: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
             invalid-lookup-uuids=[
                 "00000000-0000-0000-0000-000000000000",
                 "0d0c4ca0-4ff1-11e4-916c-0800200c9a66",
                 "41c82c87-7afb-4024-ba57-13d2c99cae77"
             ]
-            # The defined merge radius for Item entities such that when two items are
-            # within the defined radius of each other, they will attempt to merge. Usually,
-            # the default radius is set to 0.5 in Vanilla, however, for performance reasons
-            # 2.5 is generally acceptable.
-            # Note: Increasing the radius higher will likely cause performance degradation
-            # with larger amount of items as they attempt to merge and search nearby
+            # The defined merge radius for Item entities such that when two items are 
+            # within the defined radius of each other, they will attempt to merge. Usually, 
+            # the default radius is set to 0.5 in Vanilla, however, for performance reasons 
+            # 2.5 is generally acceptable. 
+            # Note: Increasing the radius higher will likely cause performance degradation 
+            # with larger amount of items as they attempt to merge and search nearby 
             # areas for more items. Setting to a negative value is not supported!
             item-merge-radius=2.5
             # If 'true', this worlds spawn will remain loaded with no players.
@@ -1945,17 +2290,17 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             leaf-decay=true
             # If 'true', this world will load on startup.
             load-on-startup=false
-            # The maximum number of queued unloaded chunks that will be unloaded in a single tick.
-            # Note: With the chunk gc enabled, this setting only applies to the ticks
-            # where the gc runs (controlled by 'chunk-gc-tick-interval')
-            # Note: If the maximum unloads is too low, too many chunks may remain
+            # The maximum number of queued unloaded chunks that will be unloaded in a single tick. 
+            # Note: With the chunk gc enabled, this setting only applies to the ticks 
+            # where the gc runs (controlled by 'chunk-gc-tick-interval') 
+            # Note: If the maximum unloads is too low, too many chunks may remain 
             # loaded on the world and increases the chance for a drop in tps. (Default: 100)
             max-chunk-unloads-per-tick=100
-            # Specifies the radius (in chunks) of where creatures will spawn.
+            # Specifies the radius (in chunks) of where creatures will spawn. 
             # This value is capped to the current view distance setting in server.properties
             mob-spawn-range=4
-            # A list of all detected portal agents used in this world.
-            # In order to override, change the target world name to any other valid world.
+            # A list of all detected portal agents used in this world. 
+            # In order to override, change the target world name to any other valid world. 
             # Note: If world is not found, it will fallback to default.
             portal-agents {
                 "minecraft:default_the_end"=DIM1
@@ -1963,8 +2308,8 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             }
             # If 'true', this world will allow PVP combat.
             pvp-enabled=true
-            # Override world distance per world/dimension
-            # The value must be greater than or equal to 3 and less than or equal to 32
+            # Override world distance per world/dimension 
+            # The value must be greater than or equal to 3 and less than or equal to 32 
             # The server-wide view distance will be used when the value is -1.
             view-distance=-1
             # If 'true', natural formation of ice and snow in supported biomes will be allowed.
@@ -1974,4 +2319,6 @@ This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 w
             # If 'true', this world will be registered.
             world-enabled=true
         }
+        # World Generation Modifiers to apply to the world
+        world-generation-modifiers=[]
     }

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -13,464 +13,1165 @@ Below is a list of available config settings and their comments inside the globa
 will not be filled immediately, and may optionally be added to the file when the server encounters them. There's also
 full example of an unmodified ``global.conf`` file at the bottom of this page, below the following list:
 
-Global Properties of Sponge
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+GlobalConfig
+============
 
-block-capturing
-===============
+**broken-mods**
 
-auto-populate
-    If 'true', newly discovered blocks will be added to this config with a default value.
-mods
-    Per-mod block id mappings for controlling capturing behavior
-block-tick-capturing
-    If 'true', individual capturing (i.e. skip bulk capturing) for scheduled ticks for
-    a block type will be performed.
-enabled
-    If 'false', all specific rules for this mod will be ignored.
-block-tick-capturing
-    If 'true', individual capturing (i.e. skip bulk capturing) for scheduled ticks for
-    a block type will be performed.
+| Stopgap measures for dealing with broken mods
 
-block-tracking
-==============
+* **Type:** ``BrokenModCategory``
 
-block-blacklist
-    Block IDs that will be blacklisted for player block placement tracking.
-enabled
-    If 'true', adds player tracking support for block positions.
-    Note: This should only be disabled if you do not care who caused a block to change.
+**bungeecord**
 
-bungeecord
-==========
+* **Type:** ``BungeeCordCategory``
 
-ip-forwarding
-    If 'true', allows BungeeCord to forward IP address, UUID, and Game Profile to this server.
+**cause-tracker**
 
-cause-tracker
-=============
+* **Type:** ``PhaseTrackerCategory``
 
-capture-async-spawning-entities
-    If set to 'true', when a mod or plugin attempts to spawn an entity
-    off the main server thread, Sponge will automatically
-    capture said entity to spawn it properly on the main
-    server thread. The catch to this is that some mods are
-    not considering the consequences of spawning an entity
-    off the server thread, and are unaware of potential race
-    conditions they may cause. If this is set to false,
-    Sponge will politely ignore the entity being spawned,
-    and emit a warning about said spawn anyways.
-generate-stacktrace-per-phase
-    If 'true', more thorough debugging for PhaseStates
-    such that a StackTrace is created every time a PhaseState
-    switches, allowing for more fine grained troubleshooting
-    in the cases of runaway phase states. Note that this is
-    not extremely performant and may have some associated costs
-    with generating the stack traces constantly.
-maximum-printed-runaway-counts
-    If verbose is not enabled, this restricts the amount of
-    runaway phase state printouts, usually happens on a server
-    where a PhaseState is not completing. Although rare, it should
-    never happen, but when it does, sometimes it can continuously print
-    more and more. This attempts to placate that while a fix can be worked on
-    to resolve the runaway. If verbose is enabled, they will always print.
-verbose
-    If 'true', the phase tracker will print out when there are too many phases
-    being entered, usually considered as an issue of phase re-entrance and
-    indicates an unexpected issue of tracking phases not to complete.
-    If this is not reported yet, please report to Sponge. If it has been
-    reported, you may disable this.
-verbose-errors
-    If 'true', the phase tracker will dump extra information about the current phases
-    when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information
-    in the exception itself can normally be used to determine the cause of the issue
+**commands**
 
-commands
-========
+* **Type:** ``CommandsCategory``
 
-aliases
-    Command aliases will resolve conflicts when multiple plugins request a specific command,
-    Correct syntax is <unqualified command>=<plugin name> e.g. "sethome=homeplugin"
-multi-world-patches
-    Patches the specified commands to respect the world of the sender instead of applying the
-    changes on the all worlds.
-config-enabled
-    This setting does nothing in the global config. In dimension/world configs, it allows the config
-    to override config(s) that it inherits from
+**debug**
 
-debug
-=====
+* **Type:** ``DebugCategory``
 
-concurrent-entity-checks
-    Detect and prevent certain attempts to use entities concurrently.
-    WARNING: May drastically decrease server performance. Only set this to 'true' to debug a pre-existing issue.
-dump-chunks-on-deadlock
-    Dump chunks in the event of a deadlock
-dump-heap-on-deadlock
-    Dump the heap in the event of a deadlock
-dump-threads-on-warn
-    Dump the server thread on deadlock warning
-thread-contention-monitoring
-    If 'true', Java's thread contention monitoring for thread dumps is enabled.
+**entity**
 
-entity
-======
+* **Type:** ``EntityCategory``
 
-collision-warn-size
-    Number of colliding entities in one spot before logging a warning. Set to 0 to disable
-count-warn-size
-    Number of entities in one dimension before logging a warning. Set to 0 to disable
-entity-painting-respawn-delay
-    Number of ticks before a painting is respawned on clients when their art is changed
-human-player-list-remove-delay
-    Number of ticks before the fake player entry of a human is removed from the tab list (range of 0 to 100 ticks).
-item-despawn-rate
-    Controls the time in ticks for when an item despawns.
-living-hard-despawn-range
-    The upper bounded range where living entities farther from a player will likely despawn
-living-soft-despawn-minimum-life
-    The amount of seconds before a living entity between the soft and hard despawn ranges from a player to be considered for despawning
-living-soft-despawn-range
-    The lower bounded range where living entities near a player may potentially despawn
-max-bounding-box-size
-    Maximum size of an entity's bounding box before removing it. Set to 0 to disable
-max-speed
-    Square of the maximum speed of an entity before removing it. Set to 0 to disable
+**entity-activation-range**
 
-entity-activation-range
-=======================
+* **Type:** ``EntityActivationRangeCategory``
 
-auto-populate
-    If 'true', newly discovered entities will be added to this config with a default value.
-defaults
-    Default activation ranges used for all entities unless overridden.
-mods
-    Per-mod overrides. Refer to the minecraft default mod for example.
+**entity-collisions**
 
-entity-collisions
+* **Type:** ``EntityCollisionCategory``
+
+**exploits**
+
+* **Type:** ``ExploitCategory``
+
+**general**
+
+* **Type:** ``GlobalGeneralCategory``
+
+**ip-sets**
+
+* **Type:** ``Map<String, List<IpSet>>``
+
+**logging**
+
+* **Type:** ``LoggingCategory``
+
+**metrics**
+
+* **Type:** ``MetricsCategory``
+
+**modules**
+
+* **Type:** ``ModuleCategory``
+
+**movement-checks**
+
+* **Type:** ``MovementChecksCategory``
+
+**optimizations**
+
+* **Type:** ``OptimizationCategory``
+
+**player-block-tracker**
+
+* **Type:** ``PlayerBlockTracker``
+
+**spawner**
+
+| Used to control spawn limits around players. 
+| Note: The radius uses the lower value of mob spawn range and server's view distance.
+
+* **Type:** ``SpawnerCategory``
+
+**sql**
+
+| Configuration options related to the Sql service, including connection aliases etc
+
+* **Type:** ``SqlCategory``
+
+**teleport-helper**
+
+| Blocks to blacklist for safe teleportation.
+
+* **Type:** ``TeleportHelperCategory``
+
+**tileentity-activation**
+
+* **Type:** ``TileEntityActivationCategory``
+
+**timings**
+
+* **Type:** ``TimingsCategory``
+
+**world**
+
+* **Type:** ``GlobalWorldCategory``
+
+BrokenModCategory
 =================
 
-auto-populate
-    If 'true', newly discovered entities/blocks will be added to this config with a default value.
-defaults
-    Default maximum collisions used for all entities/blocks unless overridden.
-max-entities-within-aabb
-    Maximum amount of entities any given entity or block can collide with. This improves
-    performance when there are more than 8 entities on top of each other such as a 1x1
-    spawn pen. Set to 0 to disable.
-mods
-    Per-mod overrides. Refer to the minecraft default mod for example.
-defaults
-    Default maximum collisions used for all entities/blocks unless overridden.
-enabled
-    If 'false', entity collision rules for this mod will be ignored.
-defaults
-    Default maximum collisions used for all entities/blocks unless overridden.
-enabled
-    If 'false', entity collision rules for this mod will be ignored.
+**broken-network-handler-mods**
 
-exploits
-========
+| A list of mod ids that have broken network handlers (they interact with the game from a Netty handler thread).
+| All network handlers from a forcibly scheduled to run on the main thread.
+| Note that this setting should be considered a last resort, and should only be used as a stopgap measure while waiting for a mod to properly fix the issue.
 
-prevent-creative-itemstack-name-exploit
-    Prevents an exploit in which the client sends a packet with the
-    itemstack name exceeding the string limit.
-prevent-sign-command-exploit
-    Prevents an exploit in which the client sends a packet to update a sign containing
-    commands from a player without permission.
+* **Type:** ``List<String>``
 
-general
-=======
-
-config-dir
-    The directory for Sponge plugin configurations, relative to the
-    execution root or specified as an absolute path.
-    Note that the default: "${CANONICAL_GAME_DIR}/config"
-    is going to use the "plugins" directory in the root game directory.
-    If you wish for plugin configs to reside within a child of the configuration
-    directory, change the value to, for example, "${CANONICAL_CONFIG_DIR}/sponge/plugins".
-    Note: It is not recommended to set this to "${CANONICAL_CONFIG_DIR}/sponge", as there is
-    a possibility that plugin configurations can conflict the Sponge core configurations.
-disable-warnings
-    Disable warning messages to server admins
-file-io-thread-sleep
-    If 'true', sleeping between chunk saves will be enabled, beware of memory issues.
-plugins-dir
-    Additional directory to search for plugins, relative to the
-    execution root or specified as an absolute path.
-    Note that the default: "${CANONICAL_MODS_DIR}/plugins"
-    is going to search for a plugins folder in the mods directory.
-    If you wish for the plugins folder to reside in the root game
-    directory, change the value to "${CANONICAL_GAME_DIR}/plugins".
-
-logging
-=======
-
-block-break
-    Log when blocks are broken
-block-modify
-    Log when blocks are modified
-block-place
-    Log when blocks are placed
-block-populate
-    Log when blocks are populated in a chunk
-block-tracking
-    Log when blocks are placed by players and tracked
-chunk-gc-queue-unload
-    Log when chunks are queued to be unloaded by the chunk garbage collector.
-chunk-load
-    Log when chunks are loaded
-chunk-unload
-    Log when chunks are unloaded
-entity-collision-checks
-    Whether to log entity collision/count checks
-entity-death
-    Log when living entities are destroyed
-entity-despawn
-    Log when living entities are despawned
-entity-spawn
-    Log when living entities are spawned
-entity-speed-removal
-    Whether to log entity removals due to speed
-exploit-itemstack-name-overflow
-    Log when server receives exploited packet with itemstack name exceeding string limit.
-exploit-respawn-invisibility
-    Log when player attempts to respawn invisible to surrounding players.
-exploit-sign-command-updates
-    Log when server receives exploited packet to update a sign containing commands from player with no permission.
-log-stacktraces
-    Add stack traces to dev logging
-world-auto-save
-    Log when a world auto-saves its chunk data. Note: This may be spammy depending on the auto-save-interval configured for world.
-
-metrics-collection
+BungeeCordCategory
 ==================
 
-default-permission
-    Determines whether newly added plugins can collect server metrics by default
-plugin-permissions
-    Per-plugin toggles indicating whether a plugin is allowed to collect server metrics
+**ip-forwarding**
 
-modules
-=======
+| If 'true', allows BungeeCord to forward IP address, UUID, and Game Profile to this server.
 
-movement-checks
-    Allows configuring Vanilla movement and speed checks
-realtime
-    Use real (wall) time instead of ticks as much as possible
-tileentity-activation
-    Controls block range and tick rate of tileentities.
-    Use with caution as this can break intended functionality.
+* **Type:** ``boolean``
+* **Default:** ``false``
 
-movement-checks
-===============
+PhaseTrackerCategory
+====================
 
-moved-wrongly
-    Controls whether the 'player/entity moved wrongly!' check will be enforced
-player-moved-too-quickly
-    Controls whether the 'player moved too quickly!' check will be enforced
-player-vehicle-moved-too-quickly
-    Controls whether the 'vehicle of player moved too quickly!' check will be enforced
+**capture-async-spawning-entities**
 
-optimizations
+| If set to 'true', when a mod or plugin attempts to spawn an entity 
+| off the main server thread, Sponge will automatically 
+| capture said entity to spawn it properly on the main 
+| server thread. The catch to this is that some mods are 
+| not considering the consequences of spawning an entity 
+| off the server thread, and are unaware of potential race 
+| conditions they may cause. If this is set to false, 
+| Sponge will politely ignore the entity being spawned, 
+| and emit a warning about said spawn anyways.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**generate-stacktrace-per-phase**
+
+| If 'true', more thorough debugging for PhaseStates 
+| such that a StackTrace is created every time a PhaseState 
+| switches, allowing for more fine grained troubleshooting 
+| in the cases of runaway phase states. Note that this is 
+| not extremely performant and may have some associated costs 
+| with generating the stack traces constantly.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**max-block-processing-depth**
+
+| The maximum number of times to recursively process transactions in a single phase.
+| Some mods may interact badly with Sponge's block capturing system, causing Sponge to
+| end up capturing block transactions every time it tries to process an existing batch.
+| Due to the recursive nature of the depth-first processing that Sponge uses to handle block transactions,
+| this can result in a stack overflow, which causes us to lose all infomration about the original cause of the issue.
+| To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds
+| this threshold.
+| The default value should almost always work properly -  it's unlikely you'll ever have to change it.
+
+* **Type:** ``int``
+* **Default:** ``100``
+
+**maximum-printed-runaway-counts**
+
+| If verbose is not enabled, this restricts the amount of 
+| runaway phase state printouts, usually happens on a server 
+| where a PhaseState is not completing. Although rare, it should 
+| never happen, but when it does, sometimes it can continuously print 
+| more and more. This attempts to placate that while a fix can be worked on 
+| to resolve the runaway. If verbose is enabled, they will always print.
+
+* **Type:** ``int``
+* **Default:** ``3``
+
+**verbose**
+
+| If 'true', the phase tracker will print out when there are too many phases 
+| being entered, usually considered as an issue of phase re-entrance and 
+| indicates an unexpected issue of tracking phases not to complete. 
+| If this is not reported yet, please report to Sponge. If it has been 
+| reported, you may disable this.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**verbose-errors**
+
+| If 'true', the phase tracker will dump extra information about the current phases 
+| when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information 
+| in the exception itself can normally be used to determine the cause of the issue
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+CommandsCategory
+================
+
+**aliases**
+
+| Command aliases will resolve conflicts when multiple plugins request a specific command, 
+| Correct syntax is <unqualified command>=<plugin name> e.g. "sethome=homeplugin"
+
+* **Type:** ``Map<String, String>``
+
+**multi-world-patches**
+
+| Patches the specified commands to respect the world of the sender instead of applying the 
+| changes on the all worlds.
+
+* **Type:** ``Map<String, Boolean>``
+
+DebugCategory
 =============
 
-async-lighting
-    Runs lighting updates asynchronously.
-enabled
-    If 'true', lighting updates are run asynchronously.
-num-threads
-    The amount of threads to dedicate for asynchronous lighting updates. (Default: 2)
-cache-tameable-owners
-    Caches tameable entities owners to avoid constant lookups against data watchers. If mods
-    cause issues, disable this.
-drops-pre-merge
-    If 'true', block item drops are pre-processed to avoid
-    having to spawn extra entities that will be merged post spawning.
-    Usually, Sponge is smart enough to determine when to attempt an item pre-merge
-    and when not to, however, in certain cases, some mods rely on items not being
-    pre-merged and actually spawned, in which case, the items will flow right through
-    without being merged.
-enchantment-helper-leak-fix
-    If 'true', provides a fix for possible leaks through
-    Minecraft's enchantment helper code that can leak
-    entity and world references without much interaction
-    Forge native (so when running SpongeForge implementation)
-    has a similar patch, but Sponge's patch works a little harder
-    at it, but Vanilla (SpongeVanilla implementation) does NOT
-    have any of the patch, leading to the recommendation that this
-    patch is enabled "for sure" when using SpongeVanilla implementation.
-    See https://bugs.mojang.com/browse/MC-128547 for more information.
-panda-redstone
-    If 'true', uses Panda4494's redstone implementation which improves performance.
-    See https://bugs.mojang.com/browse/MC-11193 for more information.
-    Note: This optimization has a few issues which are explained in the bug report.
-structure-saving
-    Handles structures that are saved to disk. Certain structures can take up large amounts
-    of disk space for very large maps and the data for these structures is only needed while the
-    world around them is generating. Disabling saving of these structures can save disk space and
-    time during saves if your world is already fully generated.
-    Warning: disabling structure saving will break the vanilla locate command.
-auto-populate
-    If 'true', newly discovered structures will be added to this config with a default value.
-mods
-    Per-mod overrides. Refer to the minecraft default mod for example.
-enabled
-    If 'false', this mod will never save its structures.
-spawner
-    Used to control spawn limits around players.
-    Note: The radius uses the lower value of mob spawn range and server's view distance.
+**concurrent-chunk-map-checks**
 
-spawner
-=======
+| Detect and prevent parts of PlayerChunkMap being called off the main thread.
+| This may decrease sever preformance, so you should only enable it when debugging a specific issue.
 
-spawn-limit-ambient
-    The number of ambients the spawner can potentially spawn around a player.
-spawn-limit-animal
-    The number of animals the spawner can potentially spawn around a player.
-spawn-limit-aquatic
-    The number of aquatics the spawner can potentially spawn around a player.
-spawn-limit-monster
-    The number of monsters the spawner can potentially spawn around a player.
-tick-rate-ambient
-    The ambient spawning tick rate. Default: 400
-tick-rate-animal
-    The animal spawning tick rate. Default: 400
-tick-rate-aquatic
-    The aquatic spawning tick rate. Default: 400
-tick-rate-monster
-    The monster spawning tick rate. Default: 1
-sql
-    Configuration options related to the Sql service, including connection aliases etc
+* **Type:** ``boolean``
+* **Default:** ``false``
 
-sql
-===
+**concurrent-entity-checks**
 
-aliases
-    Aliases for SQL connections, in the format jdbc:protocol://[username[:password]@]host/database
-teleport-helper
-    Blocks to blacklist for safe teleportation.
+| Detect and prevent certain attempts to use entities concurrently. 
+| WARNING: May drastically decrease server performance. Only set this to 'true' to debug a pre-existing issue.
 
-teleport-helper
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**dump-chunks-on-deadlock**
+
+| Dump chunks in the event of a deadlock
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**dump-heap-on-deadlock**
+
+| Dump the heap in the event of a deadlock
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**dump-threads-on-warn**
+
+| Dump the server thread on deadlock warning
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**thread-contention-monitoring**
+
+| If 'true', Java's thread contention monitoring for thread dumps is enabled.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+EntityCategory
+==============
+
+**collision-warn-size**
+
+| Number of colliding entities in one spot before logging a warning. Set to 0 to disable
+
+* **Type:** ``int``
+* **Default:** ``200``
+
+**count-warn-size**
+
+| Number of entities in one dimension before logging a warning. Set to 0 to disable
+
+* **Type:** ``int``
+* **Default:** ``0``
+
+**entity-painting-respawn-delay**
+
+| Number of ticks before a painting is respawned on clients when their art is changed
+
+* **Type:** ``int``
+* **Default:** ``2``
+
+**human-player-list-remove-delay**
+
+| Number of ticks before the fake player entry of a human is removed from the tab list (range of 0 to 100 ticks).
+
+* **Type:** ``int``
+* **Default:** ``10``
+
+**item-despawn-rate**
+
+| Controls the time in ticks for when an item despawns.
+
+* **Type:** ``int``
+* **Default:** ``6000``
+
+**living-hard-despawn-range**
+
+| The upper bounded range where living entities farther from a player will likely despawn
+
+* **Type:** ``int``
+* **Default:** ``128``
+
+**living-soft-despawn-minimum-life**
+
+| The amount of seconds before a living entity between the soft and hard despawn ranges from a player to be considered for despawning
+
+* **Type:** ``int``
+* **Default:** ``30``
+
+**living-soft-despawn-range**
+
+| The lower bounded range where living entities near a player may potentially despawn
+
+* **Type:** ``int``
+* **Default:** ``32``
+
+**max-bounding-box-size**
+
+| Maximum size of an entity's bounding box before removing it. Set to 0 to disable
+
+* **Type:** ``int``
+* **Default:** ``1000``
+
+**max-speed**
+
+| Square of the maximum speed of an entity before removing it. Set to 0 to disable
+
+* **Type:** ``int``
+* **Default:** ``100``
+
+EntityActivationRangeCategory
+=============================
+
+**auto-populate**
+
+| If 'true', newly discovered entities will be added to this config with a default value.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**defaults**
+
+| Default activation ranges used for all entities unless overridden.
+
+* **Type:** ``Map<String, Integer>``
+
+**mods**
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+
+* **Type:** ``Map<String, EntityActivationModCategory>``
+
+EntityCollisionCategory
+=======================
+
+**auto-populate**
+
+| If 'true', newly discovered entities/blocks will be added to this config with a default value.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**defaults**
+
+| Default maximum collisions used for all entities/blocks unless overridden.
+
+* **Type:** ``Map<String, Integer>``
+
+**max-entities-within-aabb**
+
+| Maximum amount of entities any given entity or block can collide with. This improves 
+| performance when there are more than 8 entities on top of each other such as a 1x1 
+| spawn pen. Set to 0 to disable.
+
+* **Type:** ``int``
+* **Default:** ``8``
+
+**mods**
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+
+* **Type:** ``Map<String, CollisionModCategory>``
+
+ExploitCategory
 ===============
 
-force-blacklist
-    If 'true', this blacklist will always be respected, otherwise, plugins can choose whether
-    or not to respect it.
-unsafe-body-block-ids
-    Block IDs that are listed here will not be selected by Sponge's safe teleport routine as
-    a safe block for players to warp into.
-    You should only list blocks here that are incorrectly selected, solid blocks that prevent
-    movement are automatically excluded.
-unsafe-floor-block-ids
-    Block IDs that are listed here will not be selected by Sponge's safe
-    teleport routine as a safe floor block.
+**prevent-creative-itemstack-name-exploit**
 
-tileentity-activation
+| Prevents an exploit in which the client sends a packet with the 
+| itemstack name exceeding the string limit.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**prevent-sign-command-exploit**
+
+| Prevents an exploit in which the client sends a packet to update a sign containing 
+| commands from a player without permission.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+GlobalGeneralCategory
 =====================
 
-auto-populate
-    If 'true', newly discovered tileentities will be added to this config with default settings.
-default-block-range
-    Default activation block range used for all tileentities unless overridden.
-default-tick-rate
-    Default tick rate used for all tileentities unless overridden.
-mods
-    Per-mod overrides. Refer to the minecraft default mod for example.
+**config-dir**
 
-timings
-=======
+| The directory for Sponge plugin configurations, relative to the  
+| execution root or specified as an absolute path. 
+| Note that the default: "${CANONICAL_GAME_DIR}/config" 
+| is going to use the "plugins" directory in the root game directory. 
+| If you wish for plugin configs to reside within a child of the configuration 
+| directory, change the value to, for example, "${CANONICAL_CONFIG_DIR}/sponge/plugins". 
+| Note: It is not recommended to set this to "${CANONICAL_CONFIG_DIR}/sponge", as there is 
+| a possibility that plugin configurations can conflict the Sponge core configurations.
+
+* **Type:** ``String``
+* **Default:** ``${CANONICAL_GAME_DIR}/config``
+
+**disable-warnings**
+
+| Disable warning messages to server admins
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**file-io-thread-sleep**
+
+| If 'true', sleeping between chunk saves will be enabled, beware of memory issues.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**plugins-dir**
+
+| Additional directory to search for plugins, relative to the 
+| execution root or specified as an absolute path. 
+| Note that the default: "${CANONICAL_MODS_DIR}/plugins" 
+| is going to search for a plugins folder in the mods directory. 
+| If you wish for the plugins folder to reside in the root game 
+| directory, change the value to "${CANONICAL_GAME_DIR}/plugins".
+
+* **Type:** ``String``
+* **Default:** ``${CANONICAL_MODS_DIR}/plugins``
+
+LoggingCategory
+===============
+
+**block-break**
+
+| Log when blocks are broken
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**block-modify**
+
+| Log when blocks are modified
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**block-place**
+
+| Log when blocks are placed
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**block-populate**
+
+| Log when blocks are populated in a chunk
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**block-tracking**
+
+| Log when blocks are placed by players and tracked
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**chunk-gc-queue-unload**
+
+| Log when chunks are queued to be unloaded by the chunk garbage collector.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**chunk-load**
+
+| Log when chunks are loaded
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**chunk-unload**
+
+| Log when chunks are unloaded
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**entity-collision-checks**
+
+| Whether to log entity collision/count checks
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**entity-death**
+
+| Log when living entities are destroyed
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**entity-despawn**
+
+| Log when living entities are despawned
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**entity-spawn**
+
+| Log when living entities are spawned
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**entity-speed-removal**
+
+| Whether to log entity removals due to speed
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**exploit-itemstack-name-overflow**
+
+| Log when server receives exploited packet with itemstack name exceeding string limit.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**exploit-respawn-invisibility**
+
+| Log when player attempts to respawn invisible to surrounding players.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**exploit-sign-command-updates**
+
+| Log when server receives exploited packet to update a sign containing commands from player with no permission.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**log-stacktraces**
+
+| Add stack traces to dev logging
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**world-auto-save**
+
+| Log when a world auto-saves its chunk data. Note: This may be spammy depending on the auto-save-interval configured for world.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+MetricsCategory
+===============
+
+**default-permission**
+
+| Determines whether plugins that are newly added are allowed to perform
+| data/metric collection by default. Plugins detected by Sponge will be added to the "plugin-permissions" section with this value.
+| 
+| Set to true to enable metric gathering by default, false otherwise.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**plugin-permissions**
+
+| Provides (or revokes) permission for metric gathering on a per plugin basis.
+| Entries should be in the format "plugin-id=<true|false>".
+| 
+| Deleting an entry from this list will reset it to the default specified in
+| "default-permission"
+
+* **Type:** ``Map<String, Boolean>``
+
+ModuleCategory
+==============
+
+**broken-mod**
+
+| Enables experimental fixes for broken mods
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**bungeecord**
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**entity-activation-range**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**entity-collisions**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**exploits**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**movement-checks**
+
+| Allows configuring Vanilla movement and speed checks
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**optimizations**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**realtime**
+
+| Use real (wall) time instead of ticks as much as possible
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**tileentity-activation**
+
+| Controls block range and tick rate of tileentities. 
+| Use with caution as this can break intended functionality.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**timings**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**tracking**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+MovementChecksCategory
+======================
+
+**moved-wrongly**
+
+| Controls whether the 'player/entity moved wrongly!' check will be enforced
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**player-moved-too-quickly**
+
+| Controls whether the 'player moved too quickly!' check will be enforced
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**player-vehicle-moved-too-quickly**
+
+| Controls whether the 'vehicle of player moved too quickly!' check will be enforced
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+OptimizationCategory
+====================
+
+**async-lighting**
+
+| Runs lighting updates asynchronously.
+
+* **Type:** ``AsyncLightingCategory``
+
+**cache-tameable-owners**
+
+| Caches tameable entities owners to avoid constant lookups against data watchers. If mods 
+| cause issues, disable this.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**drops-pre-merge**
+
+| If 'true', block item drops are pre-processed to avoid 
+| having to spawn extra entities that will be merged post spawning. 
+| Usually, Sponge is smart enough to determine when to attempt an item pre-merge 
+| and when not to, however, in certain cases, some mods rely on items not being 
+| pre-merged and actually spawned, in which case, the items will flow right through 
+| without being merged.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**enchantment-helper-leak-fix**
+
+| If 'true', provides a fix for possible leaks through
+| Minecraft's enchantment helper code that can leak
+| entity and world references without much interaction
+| Forge native (so when running SpongeForge implementation)
+| has a similar patch, but Sponge's patch works a little harder
+| at it, but Vanilla (SpongeVanilla implementation) does NOT
+| have any of the patch, leading to the recommendation that this
+| patch is enabled "for sure" when using SpongeVanilla implementation.
+| See https://bugs.mojang.com/browse/MC-128547 for more information.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**faster-thread-checks**
+
+| If 'true', allows for Sponge to make better assumptinos on single threaded
+| operations with relation to various checks for server threaded operations.
+| This is default to true due to Sponge being able to precisely inject when
+| the server thread is available. This should make an already fast operation
+| much faster for better thread checks to ensure stability of sponge's systems.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**map-optimization**
+
+| If 'true', re-writes the incredibly inefficient Vanilla Map code.
+| This yields enormous performance enhancements when using many maps, but has a tiny chance of breaking mods that invasively modify Vanilla.It is strongly reccomended to keep this on, unless explicitly advised otherwise by a Sponge developer
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**panda-redstone**
+
+| If 'true', uses Panda4494's redstone implementation which improves performance. 
+| See https://bugs.mojang.com/browse/MC-11193 for more information. 
+| Note: This optimization has a few issues which are explained in the bug report.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**structure-saving**
+
+| Handles structures that are saved to disk. Certain structures can take up large amounts 
+| of disk space for very large maps and the data for these structures is only needed while the 
+| world around them is generating. Disabling saving of these structures can save disk space and 
+| time during saves if your world is already fully generated. 
+| Warning: disabling structure saving will break the vanilla locate command.
+
+* **Type:** ``StructureSaveCategory``
+
+PlayerBlockTracker
+==================
+
+**block-blacklist**
+
+| Block IDs that will be blacklisted for player block placement tracking.
+
+* **Type:** ``List<String>``
+
+**enabled**
+
+| If 'true', adds player tracking support for block positions. 
+| Note: This should only be disabled if you do not care who caused a block to change.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+SpawnerCategory
+===============
+
+**spawn-limit-ambient**
+
+| The number of ambients the spawner can potentially spawn around a player.
+
+* **Type:** ``int``
+* **Default:** ``15``
+
+**spawn-limit-animal**
+
+| The number of animals the spawner can potentially spawn around a player.
+
+* **Type:** ``int``
+* **Default:** ``15``
+
+**spawn-limit-aquatic**
+
+| The number of aquatics the spawner can potentially spawn around a player.
+
+* **Type:** ``int``
+* **Default:** ``5``
+
+**spawn-limit-monster**
+
+| The number of monsters the spawner can potentially spawn around a player.
+
+* **Type:** ``int``
+* **Default:** ``70``
+
+**tick-rate-ambient**
+
+| The ambient spawning tick rate. Default: 400
+
+* **Type:** ``int``
+* **Default:** ``400``
+
+**tick-rate-animal**
+
+| The animal spawning tick rate. Default: 400
+
+* **Type:** ``int``
+* **Default:** ``400``
+
+**tick-rate-aquatic**
+
+| The aquatic spawning tick rate. Default: 400
+
+* **Type:** ``int``
+* **Default:** ``400``
+
+**tick-rate-monster**
+
+| The monster spawning tick rate. Default: 1
+
+* **Type:** ``int``
+* **Default:** ``1``
+
+SqlCategory
+===========
+
+**aliases**
+
+| Aliases for SQL connections, in the format jdbc:protocol://[username[:password]@]host/database
+
+* **Type:** ``Map<String, String>``
+
+TeleportHelperCategory
+======================
+
+**force-blacklist**
+
+| If 'true', this blacklist will always be respected, otherwise, plugins can choose whether 
+| or not to respect it.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**unsafe-body-block-ids**
+
+| Block IDs that are listed here will not be selected by Sponge's safe teleport routine as 
+| a safe block for players to warp into. 
+| You should only list blocks here that are incorrectly selected, solid blocks that prevent 
+| movement are automatically excluded.
+
+* **Type:** ``List<String>``
+
+**unsafe-floor-block-ids**
+
+| Block IDs that are listed here will not be selected by Sponge's safe 
+| teleport routine as a safe floor block.
+
+* **Type:** ``List<String>``
+
+TileEntityActivationCategory
+============================
+
+**auto-populate**
+
+| If 'true', newly discovered tileentities will be added to this config with default settings.
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**default-block-range**
+
+| Default activation block range used for all tileentities unless overridden.
+
+* **Type:** ``int``
+* **Default:** ``64``
+
+**default-tick-rate**
+
+| Default tick rate used for all tileentities unless overridden.
+
+* **Type:** ``int``
+* **Default:** ``1``
+
+**mods**
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+
+* **Type:** ``Map<String, TileEntityActivationModCategory>``
+
+TimingsCategory
+===============
+
+**enabled**
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**hidden-config-entries**
+
+* **Type:** ``List<String>``
+
+**history-interval**
+
+* **Type:** ``int``
+* **Default:** ``300``
+
+**history-length**
+
+* **Type:** ``int``
+* **Default:** ``3600``
+
+**server-name-privacy**
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**verbose**
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+GlobalWorldCategory
+===================
+
+**auto-player-save-interval**
+
+| The auto-save tick interval used when saving global player data. (Default: 900) 
+| Note: 20 ticks is equivalent to 1 second. Set to 0 to disable.
+
+* **Type:** ``int``
+* **Default:** ``900``
+
+**auto-save-interval**
+
+| The auto-save tick interval used to save all loaded chunks in a world. 
+| Set to 0 to disable. (Default: 900) 
+| Note: 20 ticks is equivalent to 1 second.
+
+* **Type:** ``int``
+* **Default:** ``900``
+
+**chunk-gc-load-threshold**
+
+| The number of newly loaded chunks before triggering a forced cleanup. 
+| Note: When triggered, the loaded chunk threshold will reset and start incrementing. 
+| Disabled by default.
+
+* **Type:** ``int``
+* **Default:** ``0``
+
+**chunk-gc-tick-interval**
+
+| The tick interval used to cleanup all inactive chunks that have leaked in a world. 
+| Set to 0 to disable which restores vanilla handling. (Default: 600)
+
+* **Type:** ``int``
+* **Default:** ``600``
+
+**chunk-unload-delay**
+
+| The number of seconds to delay a chunk unload once marked inactive. (Default: 15) 
+| Note: This gets reset if the chunk becomes active again.
+
+* **Type:** ``int``
+* **Default:** ``15``
+
+**deny-chunk-requests**
+
+| If 'true', any request for a chunk not currently loaded will be denied (exceptions apply 
+| for things like world gen and player movement). 
+| Warning: As this is an experimental setting for performance gain, if you encounter any issues 
+| then we recommend disabling it.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**flowing-lava-decay**
+
+| Lava behaves like vanilla water when source block is removed
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**gameprofile-lookup-batch-size**
+
+| The amount of GameProfile requests to make against Mojang's session server. (Default: 1) 
+| Note: Mojang accepts a maximum of 600 requests every 10 minutes from a single IP address. 
+| If you are running multiple servers behind the same IP, it is recommended to raise the 'gameprofile-task-interval' setting  
+| in order to compensate for the amount requests being sent. 
+| Finally, if set to 0 or less, the default batch size will be used. 
+| For more information visit http://wiki.vg/Mojang_API
+
+* **Type:** ``int``
+* **Default:** ``1``
+
+**gameprofile-lookup-task-interval**
+
+| The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. (Default: 4) 
+| Note: This setting should be raised if you experience the following error: 
+| "The client has sent too many requests within a certain amount of time". 
+| Finally, if set to 0 or less, the default interval will be used.
+
+* **Type:** ``int``
+* **Default:** ``4``
+
+**generate-spawn-on-load**
+
+| If 'true', this world will generate its spawn the moment its loaded.
+
+* **Type:** ``Boolean``
+
+**infinite-water-source**
+
+| Vanilla water source behavior - is infinite
+
+* **Type:** ``boolean``
+* **Default:** ``false``
+
+**invalid-lookup-uuids**
+
+| The list of uuid's that should never perform a lookup against Mojang's session server. 
+| Note: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
+
+* **Type:** ``List<UUID>``
+
+**item-merge-radius**
+
+| The defined merge radius for Item entities such that when two items are 
+| within the defined radius of each other, they will attempt to merge. Usually, 
+| the default radius is set to 0.5 in Vanilla, however, for performance reasons 
+| 2.5 is generally acceptable. 
+| Note: Increasing the radius higher will likely cause performance degradation 
+| with larger amount of items as they attempt to merge and search nearby 
+| areas for more items. Setting to a negative value is not supported!
+
+* **Type:** ``double``
+* **Default:** ``2.5``
+
+**keep-spawn-loaded**
+
+| If 'true', this worlds spawn will remain loaded with no players.
+
+* **Type:** ``Boolean``
+* **Default:** ``true``
+
+**leaf-decay**
+
+| If 'true', natural leaf decay is allowed.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**load-on-startup**
+
+| If 'true', this world will load on startup.
+
+* **Type:** ``Boolean``
+* **Default:** ``true``
+
+**max-chunk-unloads-per-tick**
+
+| The maximum number of queued unloaded chunks that will be unloaded in a single tick. 
+| Note: With the chunk gc enabled, this setting only applies to the ticks 
+| where the gc runs (controlled by 'chunk-gc-tick-interval') 
+| Note: If the maximum unloads is too low, too many chunks may remain 
+| loaded on the world and increases the chance for a drop in tps. (Default: 100)
+
+* **Type:** ``int``
+* **Default:** ``100``
+
+**mob-spawn-range**
+
+| Specifies the radius (in chunks) of where creatures will spawn. 
+| This value is capped to the current view distance setting in server.properties
+
+* **Type:** ``int``
+* **Default:** ``4``
+
+**portal-agents**
+
+| A list of all detected portal agents used in this world. 
+| In order to override, change the target world name to any other valid world. 
+| Note: If world is not found, it will fallback to default.
+
+* **Type:** ``Map<String, String>``
+
+**pvp-enabled**
+
+| If 'true', this world will allow PVP combat.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**view-distance**
+
+| Override world distance per world/dimension 
+| The value must be greater than or equal to 3 and less than or equal to 32 
+| The server-wide view distance will be used when the value is -1.
+
+* **Type:** ``int``
+* **Default:** ``-1``
+
+**weather-ice-and-snow**
+
+| If 'true', natural formation of ice and snow in supported biomes will be allowed.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**weather-thunder**
+
+| If 'true', thunderstorms will be initiated in supported biomes.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
+
+**world-enabled**
+
+| If 'true', this world will be registered.
+
+* **Type:** ``boolean``
+* **Default:** ``true``
 
 
-world
-=====
-
-auto-player-save-interval
-    The auto-save tick interval used when saving global player data. (Default: 900)
-    Note: 20 ticks is equivalent to 1 second. Set to 0 to disable.
-auto-save-interval
-    The auto-save tick interval used to save all loaded chunks in a world.
-    Set to 0 to disable. (Default: 900)
-    Note: 20 ticks is equivalent to 1 second.
-chunk-gc-load-threshold
-    The number of newly loaded chunks before triggering a forced cleanup.
-    Note: When triggered, the loaded chunk threshold will reset and start incrementing.
-    Disabled by default.
-chunk-gc-tick-interval
-    The tick interval used to cleanup all inactive chunks that have leaked in a world.
-    Set to 0 to disable which restores vanilla handling. (Default: 600)
-chunk-unload-delay
-    The number of seconds to delay a chunk unload once marked inactive. (Default: 15)
-    Note: This gets reset if the chunk becomes active again.
-deny-chunk-requests
-    If 'true', any request for a chunk not currently loaded will be denied (exceptions apply
-    for things like world gen and player movement).
-    Warning: As this is an experimental setting for performance gain, if you encounter any issues
-    then we recommend disabling it.
-flowing-lava-decay
-    Lava behaves like vanilla water when source block is removed
-gameprofile-lookup-batch-size
-    The amount of GameProfile requests to make against Mojang's session server. (Default: 1)
-    Note: Mojang accepts a maximum of 600 requests every 10 minutes from a single IP address.
-    If you are running multiple servers behind the same IP, it is recommended to raise the 'gameprofile-task-interval' setting
-    in order to compensate for the amount requests being sent.
-    Finally, if set to 0 or less, the default batch size will be used.
-    For more information visit https://wiki.vg/Mojang_API
-gameprofile-lookup-task-interval
-    The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. (Default: 4)
-    Note: This setting should be raised if you experience the following error:
-    "The client has sent too many requests within a certain amount of time".
-    Finally, if set to 0 or less, the default interval will be used.
-generate-spawn-on-load
-    If 'true', this world will generate its spawn the moment its loaded.
-infinite-water-source
-    Vanilla water source behavior - is infinite
-invalid-lookup-uuids
-    The list of uuid's that should never perform a lookup against Mojang's session server.
-    Note: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
-item-merge-radius
-    The defined merge radius for Item entities such that when two items are
-    within the defined radius of each other, they will attempt to merge. Usually,
-    the default radius is set to 0.5 in Vanilla, however, for performance reasons
-    2.5 is generally acceptable.
-    Note: Increasing the radius higher will likely cause performance degradation
-    with larger amount of items as they attempt to merge and search nearby
-    areas for more items. Setting to a negative value is not supported!
-keep-spawn-loaded
-    If 'true', this worlds spawn will remain loaded with no players.
-leaf-decay
-    If 'true', natural leaf decay is allowed.
-load-on-startup
-    If 'true', this world will load on startup.
-max-chunk-unloads-per-tick
-    The maximum number of queued unloaded chunks that will be unloaded in a single tick.
-    Note: With the chunk gc enabled, this setting only applies to the ticks
-    where the gc runs (controlled by 'chunk-gc-tick-interval')
-    Note: If the maximum unloads is too low, too many chunks may remain
-    loaded on the world and increases the chance for a drop in tps. (Default: 100)
-mob-spawn-range
-    Specifies the radius (in chunks) of where creatures will spawn.
-    This value is capped to the current view distance setting in server.properties
-portal-agents
-    A list of all detected portal agents used in this world.
-    In order to override, change the target world name to any other valid world.
-    Note: If world is not found, it will fallback to default.
-pvp-enabled
-    If 'true', this world will allow PVP combat.
-view-distance
-    Override world distance per world/dimension
-    The value must be greater than or equal to 3 and less than or equal to 32
-    The server-wide view distance will be used when the value is -1.
-weather-ice-and-snow
-    If 'true', natural formation of ice and snow in supported biomes will be allowed.
-weather-thunder
-    If 'true', thunderstorms will be initiated in supported biomes.
-world-enabled
-    If 'true', this world will be registered.
 
 ------------------------------------------------------------------------------------------------------------
 
-This config was generated using SpongeForge build 3442 (with Forge 2705), SpongeAPI version 7.1.0:
+This config was generated using SpongeForge recommendation 5 (SpongeForge 3554 with Forge 2768), SpongeAPI version 7.1:
 
 .. code-block:: guess
 
@@ -647,12 +1348,42 @@ This config was generated using SpongeForge build 3442 (with Forge 2705), Sponge
             }
         }
         exploits {
+            # If limit-book-size is enabled, controls the multiplier applied to each book page size
+            book-size-total-multiplier=0.98
+            # Enables filtering invalid entities when a chunk is being saved
+            # such that the entity that does not "belong" in the saving
+            # chunk will not be saved, and forced an update to the world's
+            # tracked entity lists for chunks.
+            # See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0311-Prevent-Saving-Bad-entities-to-chunks.patch
+            filter-invalid-entities-on-chunk-save=true
+            # Limits the size of a book that can be sent by the client.
+            # See https://github.com/PaperMC/Paper/blob/f8058a8187da9f6185d95bb786783e12c79c8b18/Spigot-Server-Patches/0403-Book-Size-Limits.patch
+            limit-book-size=true
+            # Enables focing a chunk load when an entity position
+            # is set. Usually due to teleportation, vehicle movement
+            # etc. can a position lead an entity to no longer exist
+            # within it's currently marked and tracked chunk. This will
+            # enable that chunk for the position is loaded. Part of several
+            # exploits.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0335-Ensure-chunks-are-always-loaded-on-hard-position-set.patch
+            load-chunk-on-position-set=true
+            # Enables forcing chunks to save when an entity is added
+            # or removed from said chunk. This is a partial fix for
+            # some exploits using vehicles.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0306-Mark-chunk-dirty-anytime-entities-change-to-guarante.patch
+            mark-chunks-as-dirty-on-entity-list-modification=true
+            # If limit-book-size is enabled, controls the maximum size of a book page
+            max-book-page-size=2560
             # Prevents an exploit in which the client sends a packet with the
             # itemstack name exceeding the string limit.
             prevent-creative-itemstack-name-exploit=true
-            # Prevents an exploit in which the client sends a packet to update a sign containing
-            # commands from a player without permission.
-            prevent-sign-command-exploit=true
+            # Enables forcing updates to the player's location on vehicle movement.
+            # This is partially required to update the server's understanding of
+            # where the player exists, and allows chunk loading issues to be avoided
+            # with laggy connections and/or hack clients.See https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0378-Sync-Player-Position-to-Vehicles.patch
+            sync-player-positions-for-vehicle-movement=true
+            # Enables forcing a chunk-tracking refresh on entity movement.
+            # This enables a guarantee that the entity is tracked in the
+            # proper chunk when moving.https://github.com/PaperMC/Paper/blob/fd1bd5223a461b6d98280bb8f2d67280a30dd24a/Spigot-Server-Patches/0315-Always-process-chunk-registration-after-moving.patch
+            update-tracked-chunk-on-entity-move=true
         }
         general {
             # The directory for Sponge plugin configurations, relative to the
@@ -728,7 +1459,7 @@ This config was generated using SpongeForge build 3442 (with Forge 2705), Sponge
             # Deleting an entry from this list will reset it to the default specified in
             # "default-permission"
             plugin-permissions {
-                test-gradle-plugin=false
+                docsconfiglister=false
             }
         }
         modules {
@@ -737,6 +1468,10 @@ This config was generated using SpongeForge build 3442 (with Forge 2705), Sponge
             bungeecord=false
             entity-activation-range=true
             entity-collisions=true
+            # Controls whether any exploit patches are applied.
+            # If there are issues with any specific exploits, please
+            # test in the exploit category first, before disabling all
+            # exploits with this toggle.
             exploits=true
             # Allows configuring Vanilla movement and speed checks
             movement-checks=false
@@ -947,7 +1682,7 @@ This config was generated using SpongeForge build 3442 (with Forge 2705), Sponge
             # If 'true', natural leaf decay is allowed.
             leaf-decay=true
             # If 'true', this world will load on startup.
-            load-on-startup=true
+            load-on-startup=false
             # The maximum number of queued unloaded chunks that will be unloaded in a single tick.
             # Note: With the chunk gc enabled, this setting only applies to the ticks
             # where the gc runs (controlled by 'chunk-gc-tick-interval')

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -30,52 +30,52 @@ GlobalConfig
 * **broken-mods**
 
   | Stopgap measures for dealing with broken mods
-  | **Type:** :ref:`BrokenModCategory<ConfigType_BrokenModCategory>`
+  | **Type:** :ref:`BrokenMod<ConfigType_BrokenMod>`
   |
 
 * **bungeecord**
 
-  | **Type:** :ref:`BungeeCordCategory<ConfigType_BungeeCordCategory>`
+  | **Type:** :ref:`BungeeCord<ConfigType_BungeeCord>`
   |
 
 * **cause-tracker**
 
-  | **Type:** :ref:`PhaseTrackerCategory<ConfigType_PhaseTrackerCategory>`
+  | **Type:** :ref:`PhaseTracker<ConfigType_PhaseTracker>`
   |
 
 * **commands**
 
-  | **Type:** :ref:`CommandsCategory<ConfigType_CommandsCategory>`
+  | **Type:** :ref:`Commands<ConfigType_Commands>`
   |
 
 * **debug**
 
-  | **Type:** :ref:`DebugCategory<ConfigType_DebugCategory>`
+  | **Type:** :ref:`Debug<ConfigType_Debug>`
   |
 
 * **entity**
 
-  | **Type:** :ref:`EntityCategory<ConfigType_EntityCategory>`
+  | **Type:** :ref:`Entity<ConfigType_Entity>`
   |
 
 * **entity-activation-range**
 
-  | **Type:** :ref:`EntityActivationRangeCategory<ConfigType_EntityActivationRangeCategory>`
+  | **Type:** :ref:`EntityActivationRange<ConfigType_EntityActivationRange>`
   |
 
 * **entity-collisions**
 
-  | **Type:** :ref:`EntityCollisionCategory<ConfigType_EntityCollisionCategory>`
+  | **Type:** :ref:`EntityCollision<ConfigType_EntityCollision>`
   |
 
 * **exploits**
 
-  | **Type:** :ref:`ExploitCategory<ConfigType_ExploitCategory>`
+  | **Type:** :ref:`Exploit<ConfigType_Exploit>`
   |
 
 * **general**
 
-  | **Type:** :ref:`GlobalGeneralCategory<ConfigType_GlobalGeneralCategory>`
+  | **Type:** :ref:`GlobalGeneral<ConfigType_GlobalGeneral>`
   |
 
 * **ip-sets**
@@ -85,27 +85,27 @@ GlobalConfig
 
 * **logging**
 
-  | **Type:** :ref:`LoggingCategory<ConfigType_LoggingCategory>`
+  | **Type:** :ref:`Logging<ConfigType_Logging>`
   |
 
 * **metrics**
 
-  | **Type:** :ref:`MetricsCategory<ConfigType_MetricsCategory>`
+  | **Type:** :ref:`Metrics<ConfigType_Metrics>`
   |
 
 * **modules**
 
-  | **Type:** :ref:`ModuleCategory<ConfigType_ModuleCategory>`
+  | **Type:** :ref:`Module<ConfigType_Module>`
   |
 
 * **movement-checks**
 
-  | **Type:** :ref:`MovementChecksCategory<ConfigType_MovementChecksCategory>`
+  | **Type:** :ref:`MovementChecks<ConfigType_MovementChecks>`
   |
 
 * **optimizations**
 
-  | **Type:** :ref:`OptimizationCategory<ConfigType_OptimizationCategory>`
+  | **Type:** :ref:`Optimization<ConfigType_Optimization>`
   |
 
 * **player-block-tracker**
@@ -117,40 +117,40 @@ GlobalConfig
 
   | Used to control spawn limits around players. 
   | **Note**: The radius uses the lower value of mob spawn range and server's view distance.
-  | **Type:** :ref:`SpawnerCategory<ConfigType_SpawnerCategory>`
+  | **Type:** :ref:`Spawner<ConfigType_Spawner>`
   |
 
 * **sql**
 
   | Configuration options related to the Sql service, including connection aliases etc
-  | **Type:** :ref:`SqlCategory<ConfigType_SqlCategory>`
+  | **Type:** :ref:`Sql<ConfigType_Sql>`
   |
 
 * **teleport-helper**
 
   | Blocks to blacklist for safe teleportation.
-  | **Type:** :ref:`TeleportHelperCategory<ConfigType_TeleportHelperCategory>`
+  | **Type:** :ref:`TeleportHelper<ConfigType_TeleportHelper>`
   |
 
 * **tileentity-activation**
 
-  | **Type:** :ref:`TileEntityActivationCategory<ConfigType_TileEntityActivationCategory>`
+  | **Type:** :ref:`TileEntityActivation<ConfigType_TileEntityActivation>`
   |
 
 * **timings**
 
-  | **Type:** :ref:`TimingsCategory<ConfigType_TimingsCategory>`
+  | **Type:** :ref:`Timings<ConfigType_Timings>`
   |
 
 * **world**
 
-  | **Type:** :ref:`GlobalWorldCategory<ConfigType_GlobalWorldCategory>`
+  | **Type:** :ref:`GlobalWorld<ConfigType_GlobalWorld>`
   |
 
-.. _ConfigType_AsyncLightingCategory:
+.. _ConfigType_AsyncLighting:
 
-AsyncLightingCategory
-=====================
+AsyncLighting
+=============
 
 | Runs lighting updates asynchronously.
 |
@@ -169,10 +169,10 @@ AsyncLightingCategory
   | **Default:** ``2``
   |
 
-.. _ConfigType_BrokenModCategory:
+.. _ConfigType_BrokenMod:
 
-BrokenModCategory
-=================
+BrokenMod
+=========
 
 | Stopgap measures for dealing with broken mods
 |
@@ -185,10 +185,10 @@ BrokenModCategory
   | **Type:** ``List<String>``
   |
 
-.. _ConfigType_BungeeCordCategory:
+.. _ConfigType_BungeeCord:
 
-BungeeCordCategory
-==================
+BungeeCord
+==========
 
 * **ip-forwarding**
 
@@ -197,10 +197,10 @@ BungeeCordCategory
   | **Default:** ``false``
   |
 
-.. _ConfigType_CollisionModCategory:
+.. _ConfigType_CollisionMod:
 
-CollisionModCategory
-====================
+CollisionMod
+============
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -228,10 +228,10 @@ CollisionModCategory
   | **Type:** ``Map<String, Integer>``
   |
 
-.. _ConfigType_CommandsCategory:
+.. _ConfigType_Commands:
 
-CommandsCategory
-================
+Commands
+========
 
 * **aliases**
 
@@ -247,10 +247,10 @@ CommandsCategory
   | **Type:** ``Map<String, Boolean>``
   |
 
-.. _ConfigType_DebugCategory:
+.. _ConfigType_Debug:
 
-DebugCategory
-=============
+Debug
+=====
 
 * **concurrent-chunk-map-checks**
 
@@ -296,10 +296,10 @@ DebugCategory
   | **Default:** ``false``
   |
 
-.. _ConfigType_EntityActivationModCategory:
+.. _ConfigType_EntityActivationMod:
 
-EntityActivationModCategory
-===========================
+EntityActivationMod
+===================
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -321,10 +321,10 @@ EntityActivationModCategory
   | **Type:** ``Map<String, Integer>``
   |
 
-.. _ConfigType_EntityActivationRangeCategory:
+.. _ConfigType_EntityActivationRange:
 
-EntityActivationRangeCategory
-=============================
+EntityActivationRange
+=====================
 
 * **auto-populate**
 
@@ -342,13 +342,13 @@ EntityActivationRangeCategory
 * **mods**
 
   | Per-mod overrides. Refer to the minecraft default mod for example.
-  | **Type:** :ref:`Map\<String, EntityActivationModCategory><ConfigType_EntityActivationModCategory>`
+  | **Type:** :ref:`Map\<String, EntityActivationMod><ConfigType_EntityActivationMod>`
   |
 
-.. _ConfigType_EntityCategory:
+.. _ConfigType_Entity:
 
-EntityCategory
-==============
+Entity
+======
 
 * **collision-warn-size**
 
@@ -420,10 +420,10 @@ EntityCategory
   | **Default:** ``100``
   |
 
-.. _ConfigType_EntityCollisionCategory:
+.. _ConfigType_EntityCollision:
 
-EntityCollisionCategory
-=======================
+EntityCollision
+===============
 
 * **auto-populate**
 
@@ -450,13 +450,13 @@ EntityCollisionCategory
 * **mods**
 
   | Per-mod overrides. Refer to the minecraft default mod for example.
-  | **Type:** :ref:`Map\<String, CollisionModCategory><ConfigType_CollisionModCategory>`
+  | **Type:** :ref:`Map\<String, CollisionMod><ConfigType_CollisionMod>`
   |
 
-.. _ConfigType_ExploitCategory:
+.. _ConfigType_Exploit:
 
-ExploitCategory
-===============
+Exploit
+=======
 
 * **prevent-creative-itemstack-name-exploit**
 
@@ -474,10 +474,10 @@ ExploitCategory
   | **Default:** ``true``
   |
 
-.. _ConfigType_GlobalGeneralCategory:
+.. _ConfigType_GlobalGeneral:
 
-GlobalGeneralCategory
-=====================
+GlobalGeneral
+=============
 
 * **config-dir**
 
@@ -519,10 +519,10 @@ GlobalGeneralCategory
   | **Default:** ``${CANONICAL_MODS_DIR}/plugins``
   |
 
-.. _ConfigType_GlobalWorldCategory:
+.. _ConfigType_GlobalWorld:
 
-GlobalWorldCategory
-===================
+GlobalWorld
+===========
 
 * **auto-player-save-interval**
 
@@ -723,10 +723,10 @@ GlobalWorldCategory
   | **Default:** ``true``
   |
 
-.. _ConfigType_LoggingCategory:
+.. _ConfigType_Logging:
 
-LoggingCategory
-===============
+Logging
+=======
 
 * **block-break**
 
@@ -855,10 +855,10 @@ LoggingCategory
   | **Default:** ``false``
   |
 
-.. _ConfigType_MetricsCategory:
+.. _ConfigType_Metrics:
 
-MetricsCategory
-===============
+Metrics
+=======
 
 * **default-permission**
 
@@ -878,10 +878,10 @@ MetricsCategory
   | **Type:** ``Map<String, Boolean>``
   |
 
-.. _ConfigType_ModuleCategory:
+.. _ConfigType_Module:
 
-ModuleCategory
-==============
+Module
+======
 
 * **broken-mod**
 
@@ -954,10 +954,10 @@ ModuleCategory
   | **Default:** ``true``
   |
 
-.. _ConfigType_MovementChecksCategory:
+.. _ConfigType_MovementChecks:
 
-MovementChecksCategory
-======================
+MovementChecks
+==============
 
 * **moved-wrongly**
 
@@ -980,15 +980,15 @@ MovementChecksCategory
   | **Default:** ``true``
   |
 
-.. _ConfigType_OptimizationCategory:
+.. _ConfigType_Optimization:
 
-OptimizationCategory
-====================
+Optimization
+============
 
 * **async-lighting**
 
   | Runs lighting updates asynchronously.
-  | **Type:** :ref:`AsyncLightingCategory<ConfigType_AsyncLightingCategory>`
+  | **Type:** :ref:`AsyncLighting<ConfigType_AsyncLighting>`
   |
 
 * **cache-tameable-owners**
@@ -1061,13 +1061,13 @@ OptimizationCategory
   | world around them is generating. Disabling saving of these structures can save disk space and 
   | time during saves if your world is already fully generated. 
   | **Warning**: disabling structure saving will break the vanilla locate command.
-  | **Type:** :ref:`StructureSaveCategory<ConfigType_StructureSaveCategory>`
+  | **Type:** :ref:`StructureSave<ConfigType_StructureSave>`
   |
 
-.. _ConfigType_PhaseTrackerCategory:
+.. _ConfigType_PhaseTracker:
 
-PhaseTrackerCategory
-====================
+PhaseTracker
+============
 
 * **capture-async-spawning-entities**
 
@@ -1161,10 +1161,10 @@ PlayerBlockTracker
   | **Default:** ``true``
   |
 
-.. _ConfigType_SpawnerCategory:
+.. _ConfigType_Spawner:
 
-SpawnerCategory
-===============
+Spawner
+=======
 
 | Used to control spawn limits around players. 
 | **Note**: The radius uses the lower value of mob spawn range and server's view distance.
@@ -1226,10 +1226,10 @@ SpawnerCategory
   | **Default:** ``1``
   |
 
-.. _ConfigType_SqlCategory:
+.. _ConfigType_Sql:
 
-SqlCategory
-===========
+Sql
+===
 
 | Configuration options related to the Sql service, including connection aliases etc
 |
@@ -1240,10 +1240,10 @@ SqlCategory
   | **Type:** ``Map<String, String>``
   |
 
-.. _ConfigType_StructureModCategory:
+.. _ConfigType_StructureMod:
 
-StructureModCategory
-====================
+StructureMod
+============
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -1260,10 +1260,10 @@ StructureModCategory
   | **Type:** ``Map<String, Boolean>``
   |
 
-.. _ConfigType_StructureSaveCategory:
+.. _ConfigType_StructureSave:
 
-StructureSaveCategory
-=====================
+StructureSave
+=============
 
 | Handles structures that are saved to disk. Certain structures can take up large amounts 
 | of disk space for very large maps and the data for these structures is only needed while the 
@@ -1288,13 +1288,13 @@ StructureSaveCategory
 * **mods**
 
   | Per-mod overrides. Refer to the minecraft default mod for example.
-  | **Type:** :ref:`Map\<String, StructureModCategory><ConfigType_StructureModCategory>`
+  | **Type:** :ref:`Map\<String, StructureMod><ConfigType_StructureMod>`
   |
 
-.. _ConfigType_TeleportHelperCategory:
+.. _ConfigType_TeleportHelper:
 
-TeleportHelperCategory
-======================
+TeleportHelper
+==============
 
 | Blocks to blacklist for safe teleportation.
 |
@@ -1323,10 +1323,10 @@ TeleportHelperCategory
   | **Type:** ``List<String>``
   |
 
-.. _ConfigType_TileEntityActivationCategory:
+.. _ConfigType_TileEntityActivation:
 
-TileEntityActivationCategory
-============================
+TileEntityActivation
+====================
 
 * **auto-populate**
 
@@ -1352,13 +1352,13 @@ TileEntityActivationCategory
 * **mods**
 
   | Per-mod overrides. Refer to the minecraft default mod for example.
-  | **Type:** :ref:`Map\<String, TileEntityActivationModCategory><ConfigType_TileEntityActivationModCategory>`
+  | **Type:** :ref:`Map\<String, TileEntityActivationMod><ConfigType_TileEntityActivationMod>`
   |
 
-.. _ConfigType_TileEntityActivationModCategory:
+.. _ConfigType_TileEntityActivationMod:
 
-TileEntityActivationModCategory
-===============================
+TileEntityActivationMod
+=======================
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -1390,10 +1390,10 @@ TileEntityActivationModCategory
   | **Type:** ``Map<String, Integer>``
   |
 
-.. _ConfigType_TimingsCategory:
+.. _ConfigType_Timings:
 
-TimingsCategory
-===============
+Timings
+=======
 
 * **enabled**
 

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -158,32 +158,10 @@ GlobalConfig
   | **Type:** ``List<String>``
   |
 
-.. _ConfigType_AsyncLighting:
-
-async-lighting
-==============
-
-| Runs lighting updates asynchronously.
-|
-
-* **enabled**
-
-  | If ``true``, lighting updates are run asynchronously.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **num-threads**
-
-  | The amount of threads to dedicate for asynchronous lighting updates.
-  | **Type:** ``int``
-  | **Default:** ``2``
-  |
-
 .. _ConfigType_BrokenMod:
 
-broken-mods
-===========
+broken-mods (BrokenMod)
+-----------------------
 
 | Stopgap measures for dealing with broken mods
 |
@@ -198,8 +176,8 @@ broken-mods
 
 .. _ConfigType_BungeeCord:
 
-bungeecord
-==========
+bungeecord (BungeeCord)
+-----------------------
 
 * **ip-forwarding**
 
@@ -208,41 +186,10 @@ bungeecord
   | **Default:** ``false``
   |
 
-.. _ConfigType_CollisionMod:
-
-mods
-====
-
-| Per-mod overrides. Refer to the minecraft default mod for example.
-|
-
-* **blocks**
-
-  | **Type:** ``Map<String, Integer>``
-  |
-
-* **defaults**
-
-  | Default maximum collisions used for all entities/blocks unless overridden.
-  | **Type:** ``Map<String, Integer>``
-  |
-
-* **enabled**
-
-  | If ``false``, entity collision rules for this mod will be ignored.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **entities**
-
-  | **Type:** ``Map<String, Integer>``
-  |
-
 .. _ConfigType_Commands:
 
-commands
-========
+commands (Commands)
+-------------------
 
 * **aliases**
 
@@ -281,8 +228,8 @@ commands
 
 .. _ConfigType_CommandsHidden:
 
-command-hiding
-==============
+commands.command-hiding (CommandsHidden)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Defines how Sponge should act when a user tries to access a command they do not have
 | permission for
@@ -308,8 +255,8 @@ command-hiding
 
 .. _ConfigType_Debug:
 
-debug
-=====
+debug (Debug)
+-------------
 
 * **concurrent-chunk-map-checks**
 
@@ -334,91 +281,10 @@ debug
   | **Default:** ``false``
   |
 
-.. _ConfigType_EigenRedstone:
-
-eigen-redstone
-==============
-
-| Uses theosib's redstone algorithms to completely overhaul the way redstone works.
-|
-
-* **enabled**
-
-  | If ``true``, uses theosib's redstone implementation which improves performance. 
-  | See https://bugs.mojang.com/browse/MC-11193 and 
-  |      https://bugs.mojang.com/browse/MC-81098 for more information. 
-  | **Note**: We cannot guarantee compatibility with mods. Use at your discretion.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **vanilla-decrement**
-
-  | If ``true``, restores the vanilla algorithm for computing wire power levels when powering off.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **vanilla-search**
-
-  | If ``true``, restores the vanilla algorithm for propagating redstone wire changes.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-.. _ConfigType_EntityActivationMod:
-
-mods
-====
-
-| Per-mod overrides. Refer to the minecraft default mod for example.
-|
-
-* **defaults**
-
-  | **Type:** ``Map<String, Integer>``
-  |
-
-* **enabled**
-
-  | If ``false``, entity activation rules for this mod will be ignored and always tick.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **entities**
-
-  | **Type:** ``Map<String, Integer>``
-  |
-
-.. _ConfigType_EntityActivationRange:
-
-entity-activation-range
-=======================
-
-* **auto-populate**
-
-  | If ``true``, newly discovered entities will be added to this config with a default value.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **defaults**
-
-  | Default activation ranges used for all entities unless overridden.
-  | **Type:** ``Map<String, Integer>``
-  |
-
-* **mods**
-
-  | Per-mod overrides. Refer to the minecraft default mod for example.
-  | **Type:** :ref:`Map\<String, EntityActivationMod><ConfigType_EntityActivationMod>`
-  |
-
 .. _ConfigType_Entity:
 
-entity
-======
+entity (Entity)
+---------------
 
 * **collision-warn-size**
 
@@ -483,10 +349,59 @@ entity
   | **Default:** ``100``
   |
 
+.. _ConfigType_EntityActivationRange:
+
+entity-activation-range (EntityActivationRange)
+-----------------------------------------------
+
+* **auto-populate**
+
+  | If ``true``, newly discovered entities will be added to this config with a default value.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **defaults**
+
+  | Default activation ranges used for all entities unless overridden.
+  | **Type:** ``Map<String, Integer>``
+  |
+
+* **mods**
+
+  | Per-mod overrides. Refer to the minecraft default mod for example.
+  | **Type:** :ref:`Map\<String, EntityActivationMod><ConfigType_EntityActivationMod>`
+  |
+
+.. _ConfigType_EntityActivationMod:
+
+entity-activation-range.mods (EntityActivationMod)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+|
+
+* **defaults**
+
+  | **Type:** ``Map<String, Integer>``
+  |
+
+* **enabled**
+
+  | If ``false``, entity activation rules for this mod will be ignored and always tick.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **entities**
+
+  | **Type:** ``Map<String, Integer>``
+  |
+
 .. _ConfigType_EntityCollision:
 
-entity-collisions
-=================
+entity-collisions (EntityCollision)
+-----------------------------------
 
 * **auto-populate**
 
@@ -510,10 +425,41 @@ entity-collisions
   | **Type:** :ref:`Map\<String, CollisionMod><ConfigType_CollisionMod>`
   |
 
+.. _ConfigType_CollisionMod:
+
+entity-collisions.mods (CollisionMod)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+|
+
+* **blocks**
+
+  | **Type:** ``Map<String, Integer>``
+  |
+
+* **defaults**
+
+  | Default maximum collisions used for all entities/blocks unless overridden.
+  | **Type:** ``Map<String, Integer>``
+  |
+
+* **enabled**
+
+  | If ``false``, entity collision rules for this mod will be ignored.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **entities**
+
+  | **Type:** ``Map<String, Integer>``
+  |
+
 .. _ConfigType_Exploit:
 
-exploits
-========
+exploits (Exploit)
+------------------
 
 * **book-size-total-multiplier**
 
@@ -603,8 +549,8 @@ exploits
 
 .. _ConfigType_GlobalGeneral:
 
-general
-=======
+general (GlobalGeneral)
+-----------------------
 
 * **config-dir**
 
@@ -641,8 +587,8 @@ general
 
 .. _ConfigType_GlobalWorld:
 
-world
-=====
+world (GlobalWorld)
+-------------------
 
 * **auto-player-save-interval**
 
@@ -820,8 +766,8 @@ world
 
 .. _ConfigType_Logging:
 
-logging
-=======
+logging (Logging)
+-----------------
 
 * **block-break**
 
@@ -952,8 +898,8 @@ logging
 
 .. _ConfigType_Metrics:
 
-metrics
-=======
+metrics (Metrics)
+-----------------
 
 * **global-state**
 
@@ -978,8 +924,8 @@ metrics
 
 .. _ConfigType_Module:
 
-modules
-=======
+modules (Module)
+----------------
 
 * **broken-mod**
 
@@ -1058,8 +1004,8 @@ modules
 
 .. _ConfigType_MovementChecks:
 
-movement-checks
-===============
+movement-checks (MovementChecks)
+--------------------------------
 
 * **moved-wrongly**
 
@@ -1084,8 +1030,8 @@ movement-checks
 
 .. _ConfigType_Optimization:
 
-optimizations
-=============
+optimizations (Optimization)
+----------------------------
 
 * **async-lighting**
 
@@ -1217,10 +1163,132 @@ optimizations
   | **Default:** ``false``
   |
 
+.. _ConfigType_AsyncLighting:
+
+optimizations.async-lighting (AsyncLighting)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Runs lighting updates asynchronously.
+|
+
+* **enabled**
+
+  | If ``true``, lighting updates are run asynchronously.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **num-threads**
+
+  | The amount of threads to dedicate for asynchronous lighting updates.
+  | **Type:** ``int``
+  | **Default:** ``2``
+  |
+
+.. _ConfigType_EigenRedstone:
+
+optimizations.eigen-redstone (EigenRedstone)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Uses theosib's redstone algorithms to completely overhaul the way redstone works.
+|
+
+* **enabled**
+
+  | If ``true``, uses theosib's redstone implementation which improves performance. 
+  | See https://bugs.mojang.com/browse/MC-11193 and 
+  |      https://bugs.mojang.com/browse/MC-81098 for more information. 
+  | **Note**: We cannot guarantee compatibility with mods. Use at your discretion.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **vanilla-decrement**
+
+  | If ``true``, restores the vanilla algorithm for computing wire power levels when powering off.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **vanilla-search**
+
+  | If ``true``, restores the vanilla algorithm for propagating redstone wire changes.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+.. _ConfigType_StructureSave:
+
+optimizations.structure-saving (StructureSave)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+| Handles structures that are saved to disk. Certain structures can take up large amounts 
+| of disk space for very large maps and the data for these structures is only needed while the 
+| world around them is generating. Disabling saving of these structures can save disk space and 
+| time during saves if your world is already fully generated. 
+| **Warning**: disabling structure saving will break the vanilla locate command.
+|
+
+* **auto-populate**
+
+  | If ``true``, newly discovered structures will be added to this config
+  | with a default value of ``true``. This is useful for finding out
+  | potentially what structures are being saved from various mods, and
+  | allowing those structures to be selectively disabled.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **enabled**
+
+  | If ``false``, disables the modification to prevent certain structures
+  | from saving to the world's data folder. If you wish to prevent certain
+  | structures from saving, leave this ``enabled=true``. When ``true``, the
+  | modification allows for specific ``named`` structures to NOT be saved to
+  | disk. Examples of some structures that are costly and somewhat irrelivent
+  | is ``mineshaft``\s, as they build several structures and save, even after
+  | finished generating.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **mods**
+
+  | Per-mod overrides. Refer to the minecraft default mod for example.
+  | **Type:** :ref:`Map\<String, StructureMod><ConfigType_StructureMod>`
+  |
+
+.. _ConfigType_StructureMod:
+
+optimizations.structure-saving.mods (StructureMod)
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+|
+
+* **enabled**
+
+  | If ``false``, this mod will never save its structures. This may
+  | break some mod functionalities when requesting to locate their
+  | structures in a World. If true, allows structures not overridden
+  | in the section below to be saved by default. If you wish to find
+  | a structure to prevent it being saved, enable ``auto-populate`` and
+  | restart the server/world instance.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **structures**
+
+  | Per structure override. Having the value of ``false`` will prevent
+  | that specific named structure from saving.
+  | **Type:** ``Map<String, Boolean>``
+  |
+
 .. _ConfigType_Permission:
 
-permission
-==========
+permission (Permission)
+-----------------------
 
 * **forge-permissions-handler**
 
@@ -1231,8 +1299,8 @@ permission
 
 .. _ConfigType_PhaseTracker:
 
-cause-tracker
-=============
+cause-tracker (PhaseTracker)
+----------------------------
 
 * **auto-fix-null-source-block-providing-tile-entities**
 
@@ -1367,8 +1435,8 @@ cause-tracker
 
 .. _ConfigType_PlayerBlockTracker:
 
-player-block-tracker
-====================
+player-block-tracker (PlayerBlockTracker)
+-----------------------------------------
 
 * **block-blacklist**
 
@@ -1386,8 +1454,8 @@ player-block-tracker
 
 .. _ConfigType_Spawner:
 
-spawner
-=======
+spawner (Spawner)
+-----------------
 
 | Used to control spawn limits around players. 
 | **Note**: The radius uses the lower value of mob spawn range and server's view distance.
@@ -1451,8 +1519,8 @@ spawner
 
 .. _ConfigType_Sql:
 
-sql
-===
+sql (Sql)
+---------
 
 | Configuration options related to the Sql service, including connection aliases etc
 |
@@ -1463,78 +1531,10 @@ sql
   | **Type:** ``Map<String, String>``
   |
 
-.. _ConfigType_StructureMod:
-
-mods
-====
-
-| Per-mod overrides. Refer to the minecraft default mod for example.
-|
-
-* **enabled**
-
-  | If ``false``, this mod will never save its structures. This may
-  | break some mod functionalities when requesting to locate their
-  | structures in a World. If true, allows structures not overridden
-  | in the section below to be saved by default. If you wish to find
-  | a structure to prevent it being saved, enable ``auto-populate`` and
-  | restart the server/world instance.
-  | **Type:** ``boolean``
-  | **Default:** ``true``
-  |
-
-* **structures**
-
-  | Per structure override. Having the value of ``false`` will prevent
-  | that specific named structure from saving.
-  | **Type:** ``Map<String, Boolean>``
-  |
-
-.. _ConfigType_StructureSave:
-
-structure-saving
-================
-
-| Handles structures that are saved to disk. Certain structures can take up large amounts 
-| of disk space for very large maps and the data for these structures is only needed while the 
-| world around them is generating. Disabling saving of these structures can save disk space and 
-| time during saves if your world is already fully generated. 
-| **Warning**: disabling structure saving will break the vanilla locate command.
-|
-
-* **auto-populate**
-
-  | If ``true``, newly discovered structures will be added to this config
-  | with a default value of ``true``. This is useful for finding out
-  | potentially what structures are being saved from various mods, and
-  | allowing those structures to be selectively disabled.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **enabled**
-
-  | If ``false``, disables the modification to prevent certain structures
-  | from saving to the world's data folder. If you wish to prevent certain
-  | structures from saving, leave this ``enabled=true``. When ``true``, the
-  | modification allows for specific ``named`` structures to NOT be saved to
-  | disk. Examples of some structures that are costly and somewhat irrelivent
-  | is ``mineshaft``\s, as they build several structures and save, even after
-  | finished generating.
-  | **Type:** ``boolean``
-  | **Default:** ``false``
-  |
-
-* **mods**
-
-  | Per-mod overrides. Refer to the minecraft default mod for example.
-  | **Type:** :ref:`Map\<String, StructureMod><ConfigType_StructureMod>`
-  |
-
 .. _ConfigType_TeleportHelper:
 
-teleport-helper
-===============
+teleport-helper (TeleportHelper)
+--------------------------------
 
 | Blocks to blacklist for safe teleportation.
 |
@@ -1565,8 +1565,8 @@ teleport-helper
 
 .. _ConfigType_TileEntityActivation:
 
-tileentity-activation
-=====================
+tileentity-activation (TileEntityActivation)
+--------------------------------------------
 
 * **auto-populate**
 
@@ -1597,8 +1597,8 @@ tileentity-activation
 
 .. _ConfigType_TileEntityActivationMod:
 
-mods
-====
+tileentity-activation.mods (TileEntityActivationMod)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -1632,8 +1632,8 @@ mods
 
 .. _ConfigType_Timings:
 
-timings
-=======
+timings (Timings)
+-----------------
 
 * **enabled**
 

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -160,8 +160,8 @@ GlobalConfig
 
 .. _ConfigType_AsyncLighting:
 
-AsyncLighting
-=============
+async-lighting
+==============
 
 | Runs lighting updates asynchronously.
 |
@@ -182,8 +182,8 @@ AsyncLighting
 
 .. _ConfigType_BrokenMod:
 
-BrokenMod
-=========
+broken-mods
+===========
 
 | Stopgap measures for dealing with broken mods
 |
@@ -198,7 +198,7 @@ BrokenMod
 
 .. _ConfigType_BungeeCord:
 
-BungeeCord
+bungeecord
 ==========
 
 * **ip-forwarding**
@@ -210,8 +210,8 @@ BungeeCord
 
 .. _ConfigType_CollisionMod:
 
-CollisionMod
-============
+mods
+====
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -241,7 +241,7 @@ CollisionMod
 
 .. _ConfigType_Commands:
 
-Commands
+commands
 ========
 
 * **aliases**
@@ -281,7 +281,7 @@ Commands
 
 .. _ConfigType_CommandsHidden:
 
-CommandsHidden
+command-hiding
 ==============
 
 | Defines how Sponge should act when a user tries to access a command they do not have
@@ -308,7 +308,7 @@ CommandsHidden
 
 .. _ConfigType_Debug:
 
-Debug
+debug
 =====
 
 * **concurrent-chunk-map-checks**
@@ -336,8 +336,8 @@ Debug
 
 .. _ConfigType_EigenRedstone:
 
-EigenRedstone
-=============
+eigen-redstone
+==============
 
 | Uses theosib's redstone algorithms to completely overhaul the way redstone works.
 |
@@ -368,8 +368,8 @@ EigenRedstone
 
 .. _ConfigType_EntityActivationMod:
 
-EntityActivationMod
-===================
+mods
+====
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -393,8 +393,8 @@ EntityActivationMod
 
 .. _ConfigType_EntityActivationRange:
 
-EntityActivationRange
-=====================
+entity-activation-range
+=======================
 
 * **auto-populate**
 
@@ -417,7 +417,7 @@ EntityActivationRange
 
 .. _ConfigType_Entity:
 
-Entity
+entity
 ======
 
 * **collision-warn-size**
@@ -485,8 +485,8 @@ Entity
 
 .. _ConfigType_EntityCollision:
 
-EntityCollision
-===============
+entity-collisions
+=================
 
 * **auto-populate**
 
@@ -512,8 +512,8 @@ EntityCollision
 
 .. _ConfigType_Exploit:
 
-Exploit
-=======
+exploits
+========
 
 * **book-size-total-multiplier**
 
@@ -603,8 +603,8 @@ Exploit
 
 .. _ConfigType_GlobalGeneral:
 
-GlobalGeneral
-=============
+general
+=======
 
 * **config-dir**
 
@@ -641,8 +641,8 @@ GlobalGeneral
 
 .. _ConfigType_GlobalWorld:
 
-GlobalWorld
-===========
+world
+=====
 
 * **auto-player-save-interval**
 
@@ -820,7 +820,7 @@ GlobalWorld
 
 .. _ConfigType_Logging:
 
-Logging
+logging
 =======
 
 * **block-break**
@@ -952,7 +952,7 @@ Logging
 
 .. _ConfigType_Metrics:
 
-Metrics
+metrics
 =======
 
 * **global-state**
@@ -978,8 +978,8 @@ Metrics
 
 .. _ConfigType_Module:
 
-Module
-======
+modules
+=======
 
 * **broken-mod**
 
@@ -1058,8 +1058,8 @@ Module
 
 .. _ConfigType_MovementChecks:
 
-MovementChecks
-==============
+movement-checks
+===============
 
 * **moved-wrongly**
 
@@ -1084,8 +1084,8 @@ MovementChecks
 
 .. _ConfigType_Optimization:
 
-Optimization
-============
+optimizations
+=============
 
 * **async-lighting**
 
@@ -1219,7 +1219,7 @@ Optimization
 
 .. _ConfigType_Permission:
 
-Permission
+permission
 ==========
 
 * **forge-permissions-handler**
@@ -1231,8 +1231,8 @@ Permission
 
 .. _ConfigType_PhaseTracker:
 
-PhaseTracker
-============
+cause-tracker
+=============
 
 * **auto-fix-null-source-block-providing-tile-entities**
 
@@ -1367,8 +1367,8 @@ PhaseTracker
 
 .. _ConfigType_PlayerBlockTracker:
 
-PlayerBlockTracker
-==================
+player-block-tracker
+====================
 
 * **block-blacklist**
 
@@ -1386,7 +1386,7 @@ PlayerBlockTracker
 
 .. _ConfigType_Spawner:
 
-Spawner
+spawner
 =======
 
 | Used to control spawn limits around players. 
@@ -1451,7 +1451,7 @@ Spawner
 
 .. _ConfigType_Sql:
 
-Sql
+sql
 ===
 
 | Configuration options related to the Sql service, including connection aliases etc
@@ -1465,8 +1465,8 @@ Sql
 
 .. _ConfigType_StructureMod:
 
-StructureMod
-============
+mods
+====
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -1492,8 +1492,8 @@ StructureMod
 
 .. _ConfigType_StructureSave:
 
-StructureSave
-=============
+structure-saving
+================
 
 | Handles structures that are saved to disk. Certain structures can take up large amounts 
 | of disk space for very large maps and the data for these structures is only needed while the 
@@ -1533,8 +1533,8 @@ StructureSave
 
 .. _ConfigType_TeleportHelper:
 
-TeleportHelper
-==============
+teleport-helper
+===============
 
 | Blocks to blacklist for safe teleportation.
 |
@@ -1565,8 +1565,8 @@ TeleportHelper
 
 .. _ConfigType_TileEntityActivation:
 
-TileEntityActivation
-====================
+tileentity-activation
+=====================
 
 * **auto-populate**
 
@@ -1597,8 +1597,8 @@ TileEntityActivation
 
 .. _ConfigType_TileEntityActivationMod:
 
-TileEntityActivationMod
-=======================
+mods
+====
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
 |
@@ -1632,7 +1632,7 @@ TileEntityActivationMod
 
 .. _ConfigType_Timings:
 
-Timings
+timings
 =======
 
 * **enabled**

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -13,1160 +13,1422 @@ Below is a list of available config settings and their comments inside the globa
 will not be filled immediately, and may optionally be added to the file when the server encounters them. There's also
 full example of an unmodified ``global.conf`` file at the bottom of this page, below the following list:
 
+.. note::
+
+    The following section headings refer to the simple class names of the configuration classes. Each of the entries in
+    a section refers to a configurable property in the associated class. The `Type` information refers to the
+    section/class that describes the nested configuration structure.
+
+.. _ConfigType_GlobalConfig:
+
 GlobalConfig
 ============
 
-**broken-mods**
+| The main configuration for Sponge: ``global.conf``
+|
 
-| Stopgap measures for dealing with broken mods
+* **broken-mods**
 
-* **Type:** ``BrokenModCategory``
+  | Stopgap measures for dealing with broken mods
+  | **Type:** :ref:`BrokenModCategory<ConfigType_BrokenModCategory>`
+  |
 
-**bungeecord**
+* **bungeecord**
 
-* **Type:** ``BungeeCordCategory``
+  | **Type:** :ref:`BungeeCordCategory<ConfigType_BungeeCordCategory>`
+  |
 
-**cause-tracker**
+* **cause-tracker**
 
-* **Type:** ``PhaseTrackerCategory``
+  | **Type:** :ref:`PhaseTrackerCategory<ConfigType_PhaseTrackerCategory>`
+  |
 
-**commands**
+* **commands**
 
-* **Type:** ``CommandsCategory``
+  | **Type:** :ref:`CommandsCategory<ConfigType_CommandsCategory>`
+  |
 
-**debug**
+* **debug**
 
-* **Type:** ``DebugCategory``
+  | **Type:** :ref:`DebugCategory<ConfigType_DebugCategory>`
+  |
 
-**entity**
+* **entity**
 
-* **Type:** ``EntityCategory``
+  | **Type:** :ref:`EntityCategory<ConfigType_EntityCategory>`
+  |
 
-**entity-activation-range**
+* **entity-activation-range**
 
-* **Type:** ``EntityActivationRangeCategory``
+  | **Type:** :ref:`EntityActivationRangeCategory<ConfigType_EntityActivationRangeCategory>`
+  |
 
-**entity-collisions**
+* **entity-collisions**
 
-* **Type:** ``EntityCollisionCategory``
+  | **Type:** :ref:`EntityCollisionCategory<ConfigType_EntityCollisionCategory>`
+  |
 
-**exploits**
+* **exploits**
 
-* **Type:** ``ExploitCategory``
+  | **Type:** :ref:`ExploitCategory<ConfigType_ExploitCategory>`
+  |
 
-**general**
+* **general**
 
-* **Type:** ``GlobalGeneralCategory``
+  | **Type:** :ref:`GlobalGeneralCategory<ConfigType_GlobalGeneralCategory>`
+  |
 
-**ip-sets**
+* **ip-sets**
 
-* **Type:** ``Map<String, List<IpSet>>``
+  | **Type:** ``Map<String, List<IpSet>>``
+  |
 
-**logging**
+* **logging**
 
-* **Type:** ``LoggingCategory``
+  | **Type:** :ref:`LoggingCategory<ConfigType_LoggingCategory>`
+  |
 
-**metrics**
+* **metrics**
 
-* **Type:** ``MetricsCategory``
+  | **Type:** :ref:`MetricsCategory<ConfigType_MetricsCategory>`
+  |
 
-**modules**
+* **modules**
 
-* **Type:** ``ModuleCategory``
+  | **Type:** :ref:`ModuleCategory<ConfigType_ModuleCategory>`
+  |
 
-**movement-checks**
+* **movement-checks**
 
-* **Type:** ``MovementChecksCategory``
+  | **Type:** :ref:`MovementChecksCategory<ConfigType_MovementChecksCategory>`
+  |
 
-**optimizations**
+* **optimizations**
 
-* **Type:** ``OptimizationCategory``
+  | **Type:** :ref:`OptimizationCategory<ConfigType_OptimizationCategory>`
+  |
 
-**player-block-tracker**
+* **player-block-tracker**
 
-* **Type:** ``PlayerBlockTracker``
+  | **Type:** :ref:`PlayerBlockTracker<ConfigType_PlayerBlockTracker>`
+  |
 
-**spawner**
+* **spawner**
 
-| Used to control spawn limits around players. 
-| Note: The radius uses the lower value of mob spawn range and server's view distance.
+  | Used to control spawn limits around players. 
+  | **Note**: The radius uses the lower value of mob spawn range and server's view distance.
+  | **Type:** :ref:`SpawnerCategory<ConfigType_SpawnerCategory>`
+  |
 
-* **Type:** ``SpawnerCategory``
+* **sql**
 
-**sql**
+  | Configuration options related to the Sql service, including connection aliases etc
+  | **Type:** :ref:`SqlCategory<ConfigType_SqlCategory>`
+  |
 
-| Configuration options related to the Sql service, including connection aliases etc
+* **teleport-helper**
 
-* **Type:** ``SqlCategory``
+  | Blocks to blacklist for safe teleportation.
+  | **Type:** :ref:`TeleportHelperCategory<ConfigType_TeleportHelperCategory>`
+  |
 
-**teleport-helper**
+* **tileentity-activation**
 
-| Blocks to blacklist for safe teleportation.
+  | **Type:** :ref:`TileEntityActivationCategory<ConfigType_TileEntityActivationCategory>`
+  |
 
-* **Type:** ``TeleportHelperCategory``
+* **timings**
 
-**tileentity-activation**
+  | **Type:** :ref:`TimingsCategory<ConfigType_TimingsCategory>`
+  |
 
-* **Type:** ``TileEntityActivationCategory``
+* **world**
 
-**timings**
+  | **Type:** :ref:`GlobalWorldCategory<ConfigType_GlobalWorldCategory>`
+  |
 
-* **Type:** ``TimingsCategory``
+.. _ConfigType_AsyncLightingCategory:
 
-**world**
+AsyncLightingCategory
+=====================
 
-* **Type:** ``GlobalWorldCategory``
+| Runs lighting updates asynchronously.
+|
+
+* **enabled**
+
+  | If ``true``, lighting updates are run asynchronously.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **num-threads**
+
+  | The amount of threads to dedicate for asynchronous lighting updates.
+  | **Type:** ``int``
+  | **Default:** ``2``
+  |
+
+.. _ConfigType_BrokenModCategory:
 
 BrokenModCategory
 =================
 
-**broken-network-handler-mods**
+| Stopgap measures for dealing with broken mods
+|
 
-| A list of mod ids that have broken network handlers (they interact with the game from a Netty handler thread).
-| All network handlers from a forcibly scheduled to run on the main thread.
-| Note that this setting should be considered a last resort, and should only be used as a stopgap measure while waiting for a mod to properly fix the issue.
+* **broken-network-handler-mods**
 
-* **Type:** ``List<String>``
+  | A list of mod ids that have broken network handlers (they interact with the game from a Netty handler thread).
+  | All network handlers from a forcibly scheduled to run on the main thread.
+  | Note that this setting should be considered a last resort, and should only be used as a stopgap measure while waiting for a mod to properly fix the issue.
+  | **Type:** ``List<String>``
+  |
+
+.. _ConfigType_BungeeCordCategory:
 
 BungeeCordCategory
 ==================
 
-**ip-forwarding**
+* **ip-forwarding**
 
-| If 'true', allows BungeeCord to forward IP address, UUID, and Game Profile to this server.
+  | If ``true``, allows BungeeCord to forward IP address, UUID, and Game Profile to this server.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+.. _ConfigType_CollisionModCategory:
 
-PhaseTrackerCategory
+CollisionModCategory
 ====================
 
-**capture-async-spawning-entities**
+| Per-mod overrides. Refer to the minecraft default mod for example.
+|
 
-| If set to 'true', when a mod or plugin attempts to spawn an entity 
-| off the main server thread, Sponge will automatically 
-| capture said entity to spawn it properly on the main 
-| server thread. The catch to this is that some mods are 
-| not considering the consequences of spawning an entity 
-| off the server thread, and are unaware of potential race 
-| conditions they may cause. If this is set to false, 
-| Sponge will politely ignore the entity being spawned, 
-| and emit a warning about said spawn anyways.
+* **blocks**
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+  | **Type:** ``Map<String, Integer>``
+  |
 
-**generate-stacktrace-per-phase**
+* **defaults**
 
-| If 'true', more thorough debugging for PhaseStates 
-| such that a StackTrace is created every time a PhaseState 
-| switches, allowing for more fine grained troubleshooting 
-| in the cases of runaway phase states. Note that this is 
-| not extremely performant and may have some associated costs 
-| with generating the stack traces constantly.
+  | Default maximum collisions used for all entities/blocks unless overridden.
+  | **Type:** ``Map<String, Integer>``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **enabled**
 
-**max-block-processing-depth**
+  | If ``false``, entity collision rules for this mod will be ignored.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-| The maximum number of times to recursively process transactions in a single phase.
-| Some mods may interact badly with Sponge's block capturing system, causing Sponge to
-| end up capturing block transactions every time it tries to process an existing batch.
-| Due to the recursive nature of the depth-first processing that Sponge uses to handle block transactions,
-| this can result in a stack overflow, which causes us to lose all infomration about the original cause of the issue.
-| To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds
-| this threshold.
-| The default value should almost always work properly -  it's unlikely you'll ever have to change it.
+* **entities**
 
-* **Type:** ``int``
-* **Default:** ``100``
+  | **Type:** ``Map<String, Integer>``
+  |
 
-**maximum-printed-runaway-counts**
-
-| If verbose is not enabled, this restricts the amount of 
-| runaway phase state printouts, usually happens on a server 
-| where a PhaseState is not completing. Although rare, it should 
-| never happen, but when it does, sometimes it can continuously print 
-| more and more. This attempts to placate that while a fix can be worked on 
-| to resolve the runaway. If verbose is enabled, they will always print.
-
-* **Type:** ``int``
-* **Default:** ``3``
-
-**verbose**
-
-| If 'true', the phase tracker will print out when there are too many phases 
-| being entered, usually considered as an issue of phase re-entrance and 
-| indicates an unexpected issue of tracking phases not to complete. 
-| If this is not reported yet, please report to Sponge. If it has been 
-| reported, you may disable this.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**verbose-errors**
-
-| If 'true', the phase tracker will dump extra information about the current phases 
-| when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information 
-| in the exception itself can normally be used to determine the cause of the issue
-
-* **Type:** ``boolean``
-* **Default:** ``false``
+.. _ConfigType_CommandsCategory:
 
 CommandsCategory
 ================
 
-**aliases**
+* **aliases**
 
-| Command aliases will resolve conflicts when multiple plugins request a specific command, 
-| Correct syntax is <unqualified command>=<plugin name> e.g. "sethome=homeplugin"
+  | Command aliases will resolve conflicts when multiple plugins request a specific command, 
+  | Correct syntax is <unqualified command>=<plugin name> e.g. ``sethome=homeplugin``
+  | **Type:** ``Map<String, String>``
+  |
 
-* **Type:** ``Map<String, String>``
+* **multi-world-patches**
 
-**multi-world-patches**
+  | Patches the specified commands to respect the world of the sender instead of applying the 
+  | changes on the all worlds.
+  | **Type:** ``Map<String, Boolean>``
+  |
 
-| Patches the specified commands to respect the world of the sender instead of applying the 
-| changes on the all worlds.
-
-* **Type:** ``Map<String, Boolean>``
+.. _ConfigType_DebugCategory:
 
 DebugCategory
 =============
 
-**concurrent-chunk-map-checks**
+* **concurrent-chunk-map-checks**
 
-| Detect and prevent parts of PlayerChunkMap being called off the main thread.
-| This may decrease sever preformance, so you should only enable it when debugging a specific issue.
+  | Detect and prevent parts of PlayerChunkMap being called off the main thread.
+  | This may decrease sever preformance, so you should only enable it when debugging a specific issue.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **concurrent-entity-checks**
 
-**concurrent-entity-checks**
+  | Detect and prevent certain attempts to use entities concurrently. 
+  | **WARNING**: May drastically decrease server performance. Only set this to ``true`` to debug a pre-existing issue.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Detect and prevent certain attempts to use entities concurrently. 
-| WARNING: May drastically decrease server performance. Only set this to 'true' to debug a pre-existing issue.
+* **dump-chunks-on-deadlock**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Dump chunks in the event of a deadlock
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**dump-chunks-on-deadlock**
+* **dump-heap-on-deadlock**
 
-| Dump chunks in the event of a deadlock
+  | Dump the heap in the event of a deadlock
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **dump-threads-on-warn**
 
-**dump-heap-on-deadlock**
+  | Dump the server thread on deadlock warning
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Dump the heap in the event of a deadlock
+* **thread-contention-monitoring**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | If ``true``, Java's thread contention monitoring for thread dumps is enabled.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**dump-threads-on-warn**
+.. _ConfigType_EntityActivationModCategory:
 
-| Dump the server thread on deadlock warning
+EntityActivationModCategory
+===========================
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+| Per-mod overrides. Refer to the minecraft default mod for example.
+|
 
-**thread-contention-monitoring**
+* **defaults**
 
-| If 'true', Java's thread contention monitoring for thread dumps is enabled.
+  | **Type:** ``Map<String, Integer>``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **enabled**
 
-EntityCategory
-==============
+  | If ``false``, entity activation rules for this mod will be ignored and always tick.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**collision-warn-size**
+* **entities**
 
-| Number of colliding entities in one spot before logging a warning. Set to 0 to disable
+  | **Type:** ``Map<String, Integer>``
+  |
 
-* **Type:** ``int``
-* **Default:** ``200``
-
-**count-warn-size**
-
-| Number of entities in one dimension before logging a warning. Set to 0 to disable
-
-* **Type:** ``int``
-* **Default:** ``0``
-
-**entity-painting-respawn-delay**
-
-| Number of ticks before a painting is respawned on clients when their art is changed
-
-* **Type:** ``int``
-* **Default:** ``2``
-
-**human-player-list-remove-delay**
-
-| Number of ticks before the fake player entry of a human is removed from the tab list (range of 0 to 100 ticks).
-
-* **Type:** ``int``
-* **Default:** ``10``
-
-**item-despawn-rate**
-
-| Controls the time in ticks for when an item despawns.
-
-* **Type:** ``int``
-* **Default:** ``6000``
-
-**living-hard-despawn-range**
-
-| The upper bounded range where living entities farther from a player will likely despawn
-
-* **Type:** ``int``
-* **Default:** ``128``
-
-**living-soft-despawn-minimum-life**
-
-| The amount of seconds before a living entity between the soft and hard despawn ranges from a player to be considered for despawning
-
-* **Type:** ``int``
-* **Default:** ``30``
-
-**living-soft-despawn-range**
-
-| The lower bounded range where living entities near a player may potentially despawn
-
-* **Type:** ``int``
-* **Default:** ``32``
-
-**max-bounding-box-size**
-
-| Maximum size of an entity's bounding box before removing it. Set to 0 to disable
-
-* **Type:** ``int``
-* **Default:** ``1000``
-
-**max-speed**
-
-| Square of the maximum speed of an entity before removing it. Set to 0 to disable
-
-* **Type:** ``int``
-* **Default:** ``100``
+.. _ConfigType_EntityActivationRangeCategory:
 
 EntityActivationRangeCategory
 =============================
 
-**auto-populate**
+* **auto-populate**
 
-| If 'true', newly discovered entities will be added to this config with a default value.
+  | If ``true``, newly discovered entities will be added to this config with a default value.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **defaults**
 
-**defaults**
+  | Default activation ranges used for all entities unless overridden.
+  | **Type:** ``Map<String, Integer>``
+  |
 
-| Default activation ranges used for all entities unless overridden.
+* **mods**
 
-* **Type:** ``Map<String, Integer>``
+  | Per-mod overrides. Refer to the minecraft default mod for example.
+  | **Type:** :ref:`Map\<String, EntityActivationModCategory><ConfigType_EntityActivationModCategory>`
+  |
 
-**mods**
+.. _ConfigType_EntityCategory:
 
-| Per-mod overrides. Refer to the minecraft default mod for example.
+EntityCategory
+==============
 
-* **Type:** ``Map<String, EntityActivationModCategory>``
+* **collision-warn-size**
+
+  | Number of colliding entities in one spot before logging a warning. Set to ``0`` to disable
+  | **Type:** ``int``
+  | **Default:** ``200``
+  |
+
+* **count-warn-size**
+
+  | Number of entities in one dimension before logging a warning. Set to ``0`` to disable
+  | **Type:** ``int``
+  | **Default:** ``0``
+  |
+
+* **entity-painting-respawn-delay**
+
+  | Number of ticks before a painting is respawned on clients when their art is changed
+  | **Type:** ``int``
+  | **Default:** ``2``
+  |
+
+* **human-player-list-remove-delay**
+
+  | Number of ticks before the fake player entry of a human is removed from the tab list (range of ``0`` to ``100`` ticks).
+  | **Type:** ``int``
+  | **Default:** ``10``
+  |
+
+* **item-despawn-rate**
+
+  | Controls the time in ticks for when an item despawns.
+  | **Type:** ``int``
+  | **Default:** ``6000``
+  |
+
+* **living-hard-despawn-range**
+
+  | The upper bounded range where living entities farther from a player will likely despawn
+  | **Type:** ``int``
+  | **Default:** ``128``
+  |
+
+* **living-soft-despawn-minimum-life**
+
+  | The amount of seconds before a living entity between the soft and hard despawn ranges from a player to be considered for despawning
+  | **Type:** ``int``
+  | **Default:** ``30``
+  |
+
+* **living-soft-despawn-range**
+
+  | The lower bounded range where living entities near a player may potentially despawn
+  | **Type:** ``int``
+  | **Default:** ``32``
+  |
+
+* **max-bounding-box-size**
+
+  | Maximum size of an entity's bounding box before removing it. Set to ``0`` to disable
+  | **Type:** ``int``
+  | **Default:** ``1000``
+  |
+
+* **max-speed**
+
+  | Square of the maximum speed of an entity before removing it. Set to ``0`` to disable
+  | **Type:** ``int``
+  | **Default:** ``100``
+  |
+
+.. _ConfigType_EntityCollisionCategory:
 
 EntityCollisionCategory
 =======================
 
-**auto-populate**
+* **auto-populate**
 
-| If 'true', newly discovered entities/blocks will be added to this config with a default value.
+  | If ``true``, newly discovered entities/blocks will be added to this config with a default value.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **defaults**
 
-**defaults**
+  | Default maximum collisions used for all entities/blocks unless overridden.
+  | **Type:** ``Map<String, Integer>``
+  |
 
-| Default maximum collisions used for all entities/blocks unless overridden.
+* **max-entities-within-aabb**
 
-* **Type:** ``Map<String, Integer>``
+  | Maximum amount of entities any given entity or block can collide with. This improves 
+  | performance when there are more than ``8`` entities on top of each other such as a 1x1 
+  | spawn pen. Set to ``0`` to disable.
+  | **Type:** ``int``
+  | **Default:** ``8``
+  |
 
-**max-entities-within-aabb**
+* **mods**
 
-| Maximum amount of entities any given entity or block can collide with. This improves 
-| performance when there are more than 8 entities on top of each other such as a 1x1 
-| spawn pen. Set to 0 to disable.
+  | Per-mod overrides. Refer to the minecraft default mod for example.
+  | **Type:** :ref:`Map\<String, CollisionModCategory><ConfigType_CollisionModCategory>`
+  |
 
-* **Type:** ``int``
-* **Default:** ``8``
-
-**mods**
-
-| Per-mod overrides. Refer to the minecraft default mod for example.
-
-* **Type:** ``Map<String, CollisionModCategory>``
+.. _ConfigType_ExploitCategory:
 
 ExploitCategory
 ===============
 
-**prevent-creative-itemstack-name-exploit**
+* **prevent-creative-itemstack-name-exploit**
 
-| Prevents an exploit in which the client sends a packet with the 
-| itemstack name exceeding the string limit.
+  | Prevents an exploit in which the client sends a packet with the 
+  | itemstack name exceeding the string limit.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **prevent-sign-command-exploit**
 
-**prevent-sign-command-exploit**
+  | Prevents an exploit in which the client sends a packet to update a sign containing 
+  | commands from a player without permission.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-| Prevents an exploit in which the client sends a packet to update a sign containing 
-| commands from a player without permission.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
+.. _ConfigType_GlobalGeneralCategory:
 
 GlobalGeneralCategory
 =====================
 
-**config-dir**
+* **config-dir**
 
-| The directory for Sponge plugin configurations, relative to the  
-| execution root or specified as an absolute path. 
-| Note that the default: "${CANONICAL_GAME_DIR}/config" 
-| is going to use the "plugins" directory in the root game directory. 
-| If you wish for plugin configs to reside within a child of the configuration 
-| directory, change the value to, for example, "${CANONICAL_CONFIG_DIR}/sponge/plugins". 
-| Note: It is not recommended to set this to "${CANONICAL_CONFIG_DIR}/sponge", as there is 
-| a possibility that plugin configurations can conflict the Sponge core configurations.
+  | The directory for Sponge plugin configurations, relative to the  
+  | execution root or specified as an absolute path. 
+  | Note that the default: ``${CANONICAL_GAME_DIR}/config`` 
+  | is going to use the ``plugins`` directory in the root game directory. 
+  | If you wish for plugin configs to reside within a child of the configuration 
+  | directory, change the value to, for example, ``${CANONICAL_CONFIG_DIR}/sponge/plugins``. 
+  | **Note**: It is not recommended to set this to ``${CANONICAL_CONFIG_DIR}/sponge``, as there is 
+  | a possibility that plugin configurations can conflict the Sponge core configurations.
+  | **Type:** ``String``
+  | **Default:** ``${CANONICAL_GAME_DIR}/config``
+  |
 
-* **Type:** ``String``
-* **Default:** ``${CANONICAL_GAME_DIR}/config``
+* **disable-warnings**
 
-**disable-warnings**
+  | Disable warning messages to server admins
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Disable warning messages to server admins
+* **file-io-thread-sleep**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | If ``true``, sleeping between chunk saves will be enabled, beware of memory issues.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**file-io-thread-sleep**
+* **plugins-dir**
 
-| If 'true', sleeping between chunk saves will be enabled, beware of memory issues.
+  | Additional directory to search for plugins, relative to the 
+  | execution root or specified as an absolute path. 
+  | Note that the default: ``${CANONICAL_MODS_DIR}/plugins`` 
+  | is going to search for a plugins folder in the mods directory. 
+  | If you wish for the plugins folder to reside in the root game 
+  | directory, change the value to ``${CANONICAL_GAME_DIR}/plugins``.
+  | **Type:** ``String``
+  | **Default:** ``${CANONICAL_MODS_DIR}/plugins``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+.. _ConfigType_GlobalWorldCategory:
 
-**plugins-dir**
+GlobalWorldCategory
+===================
 
-| Additional directory to search for plugins, relative to the 
-| execution root or specified as an absolute path. 
-| Note that the default: "${CANONICAL_MODS_DIR}/plugins" 
-| is going to search for a plugins folder in the mods directory. 
-| If you wish for the plugins folder to reside in the root game 
-| directory, change the value to "${CANONICAL_GAME_DIR}/plugins".
+* **auto-player-save-interval**
 
-* **Type:** ``String``
-* **Default:** ``${CANONICAL_MODS_DIR}/plugins``
+  | The auto-save tick interval used when saving global player data. 
+  | **Note**: ``20`` ticks is equivalent to ``1`` second. Set to ``0`` to disable.
+  | **Type:** ``int``
+  | **Default:** ``900``
+  |
+
+* **auto-save-interval**
+
+  | The auto-save tick interval used to save all loaded chunks in a world. 
+  | Set to ``0`` to disable. 
+  | **Note**: ``20`` ticks is equivalent to ``1`` second.
+  | **Type:** ``int``
+  | **Default:** ``900``
+  |
+
+* **chunk-gc-load-threshold**
+
+  | The number of newly loaded chunks before triggering a forced cleanup. 
+  | **Note**: When triggered, the loaded chunk threshold will reset and start incrementing. 
+  | Disabled by default.
+  | **Type:** ``int``
+  | **Default:** ``0``
+  |
+
+* **chunk-gc-tick-interval**
+
+  | The tick interval used to cleanup all inactive chunks that have leaked in a world. 
+  | Set to ``0`` to disable which restores vanilla handling.
+  | **Type:** ``int``
+  | **Default:** ``600``
+  |
+
+* **chunk-unload-delay**
+
+  | The number of seconds to delay a chunk unload once marked inactive. 
+  | **Note**: This gets reset if the chunk becomes active again.
+  | **Type:** ``int``
+  | **Default:** ``15``
+  |
+
+* **deny-chunk-requests**
+
+  | If ``true``, any request for a chunk not currently loaded will be denied (exceptions apply 
+  | for things like world gen and player movement). 
+  | **Warning**: As this is an experimental setting for performance gain, if you encounter any issues 
+  | then we recommend disabling it.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **flowing-lava-decay**
+
+  | Lava behaves like vanilla water when source block is removed
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **gameprofile-lookup-batch-size**
+
+  | The amount of GameProfile requests to make against Mojang's session server. 
+  | **Note**: Mojang accepts a maximum of ``600`` requests every ``10`` minutes from a single IP address. 
+  | If you are running multiple servers behind the same IP, it is recommended to raise the ``gameprofile-task-interval`` setting  
+  | in order to compensate for the amount requests being sent. 
+  | Finally, if set to ``0`` or less, the default batch size will be used. 
+  | For more information visit http://wiki.vg/Mojang_API
+  | **Type:** ``int``
+  | **Default:** ``1``
+  |
+
+* **gameprofile-lookup-task-interval**
+
+  | The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. 
+  | **Note**: This setting should be raised if you experience the following error: 
+  | ``The client has sent too many requests within a certain amount of time``. 
+  | Finally, if set to ``0`` or less, the default interval will be used.
+  | **Type:** ``int``
+  | **Default:** ``4``
+  |
+
+* **generate-spawn-on-load**
+
+  | If ``true``, this world will generate its spawn the moment its loaded.
+  | **Type:** ``Boolean``
+  |
+
+* **infinite-water-source**
+
+  | Vanilla water source behavior - is infinite
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **invalid-lookup-uuids**
+
+  | The list of uuid's that should never perform a lookup against Mojang's session server. 
+  | **Note**: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
+  | **Type:** ``List<UUID>``
+  |
+
+* **item-merge-radius**
+
+  | The defined merge radius for Item entities such that when two items are 
+  | within the defined radius of each other, they will attempt to merge. Usually, 
+  | the default radius is set to ``0.5`` in Vanilla, however, for performance reasons 
+  | ``2.5`` is generally acceptable. 
+  | **Note**: Increasing the radius higher will likely cause performance degradation 
+  | with larger amount of items as they attempt to merge and search nearby 
+  | areas for more items. Setting to a negative value is not supported!
+  | **Type:** ``double``
+  | **Default:** ``2.5``
+  |
+
+* **keep-spawn-loaded**
+
+  | If ``true``, this worlds spawn will remain loaded with no players.
+  | **Type:** ``Boolean``
+  | **Default:** ``true``
+  |
+
+* **leaf-decay**
+
+  | If ``true``, natural leaf decay is allowed.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **load-on-startup**
+
+  | If ``true``, this world will load on startup.
+  | **Type:** ``Boolean``
+  | **Default:** ``true``
+  |
+
+* **max-chunk-unloads-per-tick**
+
+  | The maximum number of queued unloaded chunks that will be unloaded in a single tick. 
+  | **Note**: With the chunk gc enabled, this setting only applies to the ticks 
+  | where the gc runs (controlled by ``chunk-gc-tick-interval``) 
+  | **Note**: If the maximum unloads is too low, too many chunks may remain 
+  | loaded on the world and increases the chance for a drop in tps.
+  | **Type:** ``int``
+  | **Default:** ``100``
+  |
+
+* **mob-spawn-range**
+
+  | Specifies the radius (in chunks) of where creatures will spawn. 
+  | This value is capped to the current view distance setting in server.properties
+  | **Type:** ``int``
+  | **Default:** ``4``
+  |
+
+* **portal-agents**
+
+  | A list of all detected portal agents used in this world. 
+  | In order to override, change the target world name to any other valid world. 
+  | **Note**: If world is not found, it will fallback to default.
+  | **Type:** ``Map<String, String>``
+  |
+
+* **pvp-enabled**
+
+  | If ``true``, this world will allow PVP combat.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **view-distance**
+
+  | Override world distance per world/dimension 
+  | The value must be greater than or equal to ``3`` and less than or equal to ``32`` 
+  | The server-wide view distance will be used when the value is ``1``.
+  | **Type:** ``int``
+  | **Default:** ``-1``
+  |
+
+* **weather-ice-and-snow**
+
+  | If ``true``, natural formation of ice and snow in supported biomes will be allowed.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **weather-thunder**
+
+  | If ``true``, thunderstorms will be initiated in supported biomes.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **world-enabled**
+
+  | If ``true``, this world will be registered.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+.. _ConfigType_LoggingCategory:
 
 LoggingCategory
 ===============
 
-**block-break**
+* **block-break**
 
-| Log when blocks are broken
+  | Log when blocks are broken
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **block-modify**
 
-**block-modify**
+  | Log when blocks are modified
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Log when blocks are modified
+* **block-place**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Log when blocks are placed
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**block-place**
+* **block-populate**
 
-| Log when blocks are placed
+  | Log when blocks are populated in a chunk
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **block-tracking**
 
-**block-populate**
+  | Log when blocks are placed by players and tracked
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Log when blocks are populated in a chunk
+* **chunk-gc-queue-unload**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Log when chunks are queued to be unloaded by the chunk garbage collector.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**block-tracking**
+* **chunk-load**
 
-| Log when blocks are placed by players and tracked
+  | Log when chunks are loaded
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **chunk-unload**
 
-**chunk-gc-queue-unload**
+  | Log when chunks are unloaded
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Log when chunks are queued to be unloaded by the chunk garbage collector.
+* **entity-collision-checks**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Whether to log entity collision/count checks
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**chunk-load**
+* **entity-death**
 
-| Log when chunks are loaded
+  | Log when living entities are destroyed
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **entity-despawn**
 
-**chunk-unload**
+  | Log when living entities are despawned
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Log when chunks are unloaded
+* **entity-spawn**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Log when living entities are spawned
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**entity-collision-checks**
+* **entity-speed-removal**
 
-| Whether to log entity collision/count checks
+  | Whether to log entity removals due to speed
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **exploit-itemstack-name-overflow**
 
-**entity-death**
+  | Log when server receives exploited packet with itemstack name exceeding string limit.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Log when living entities are destroyed
+* **exploit-respawn-invisibility**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Log when player attempts to respawn invisible to surrounding players.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**entity-despawn**
+* **exploit-sign-command-updates**
 
-| Log when living entities are despawned
+  | Log when server receives exploited packet to update a sign containing commands from player with no permission.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **log-stacktraces**
 
-**entity-spawn**
+  | Add stack traces to dev logging
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Log when living entities are spawned
+* **world-auto-save**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | Log when a world auto-saves its chunk data. 
+  | **Note**: This may be spammy depending on the auto-save-interval configured for world.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**entity-speed-removal**
-
-| Whether to log entity removals due to speed
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**exploit-itemstack-name-overflow**
-
-| Log when server receives exploited packet with itemstack name exceeding string limit.
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**exploit-respawn-invisibility**
-
-| Log when player attempts to respawn invisible to surrounding players.
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**exploit-sign-command-updates**
-
-| Log when server receives exploited packet to update a sign containing commands from player with no permission.
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**log-stacktraces**
-
-| Add stack traces to dev logging
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**world-auto-save**
-
-| Log when a world auto-saves its chunk data. Note: This may be spammy depending on the auto-save-interval configured for world.
-
-* **Type:** ``boolean``
-* **Default:** ``false``
+.. _ConfigType_MetricsCategory:
 
 MetricsCategory
 ===============
 
-**default-permission**
+* **default-permission**
 
-| Determines whether plugins that are newly added are allowed to perform
-| data/metric collection by default. Plugins detected by Sponge will be added to the "plugin-permissions" section with this value.
-| 
-| Set to true to enable metric gathering by default, false otherwise.
+  | Determines whether plugins that are newly added are allowed to perform
+  | data/metric collection by default. Plugins detected by Sponge will be added to the ``plugin-permissions`` section with this value.
+  | Set to true to enable metric gathering by default, false otherwise.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **plugin-permissions**
 
-**plugin-permissions**
+  | Provides (or revokes) permission for metric gathering on a per plugin basis.
+  | Entries should be in the format ``plugin-id=<true|false>``.
+  | Deleting an entry from this list will reset it to the default specified in
+  | ``default-permission``
+  | **Type:** ``Map<String, Boolean>``
+  |
 
-| Provides (or revokes) permission for metric gathering on a per plugin basis.
-| Entries should be in the format "plugin-id=<true|false>".
-| 
-| Deleting an entry from this list will reset it to the default specified in
-| "default-permission"
-
-* **Type:** ``Map<String, Boolean>``
+.. _ConfigType_ModuleCategory:
 
 ModuleCategory
 ==============
 
-**broken-mod**
+* **broken-mod**
 
-| Enables experimental fixes for broken mods
+  | Enables experimental fixes for broken mods
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **bungeecord**
 
-**bungeecord**
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **entity-activation-range**
 
-**entity-activation-range**
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **entity-collisions**
 
-**entity-collisions**
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **exploits**
 
-**exploits**
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **movement-checks**
 
-**movement-checks**
+  | Allows configuring Vanilla movement and speed checks
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-| Allows configuring Vanilla movement and speed checks
+* **optimizations**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**optimizations**
+* **realtime**
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+  | Use real (wall) time instead of ticks as much as possible
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**realtime**
+* **tileentity-activation**
 
-| Use real (wall) time instead of ticks as much as possible
+  | Controls block range and tick rate of tileentities. 
+  | Use with caution as this can break intended functionality.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **timings**
 
-**tileentity-activation**
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-| Controls block range and tick rate of tileentities. 
-| Use with caution as this can break intended functionality.
+* **tracking**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**timings**
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**tracking**
-
-* **Type:** ``boolean``
-* **Default:** ``true``
+.. _ConfigType_MovementChecksCategory:
 
 MovementChecksCategory
 ======================
 
-**moved-wrongly**
+* **moved-wrongly**
 
-| Controls whether the 'player/entity moved wrongly!' check will be enforced
+  | Controls whether the ``player/entity moved wrongly!`` check will be enforced
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **player-moved-too-quickly**
 
-**player-moved-too-quickly**
+  | Controls whether the ``player moved too quickly!`` check will be enforced
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-| Controls whether the 'player moved too quickly!' check will be enforced
+* **player-vehicle-moved-too-quickly**
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+  | Controls whether the ``vehicle of player moved too quickly!`` check will be enforced
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**player-vehicle-moved-too-quickly**
-
-| Controls whether the 'vehicle of player moved too quickly!' check will be enforced
-
-* **Type:** ``boolean``
-* **Default:** ``true``
+.. _ConfigType_OptimizationCategory:
 
 OptimizationCategory
 ====================
 
-**async-lighting**
+* **async-lighting**
 
-| Runs lighting updates asynchronously.
+  | Runs lighting updates asynchronously.
+  | **Type:** :ref:`AsyncLightingCategory<ConfigType_AsyncLightingCategory>`
+  |
 
-* **Type:** ``AsyncLightingCategory``
+* **cache-tameable-owners**
 
-**cache-tameable-owners**
+  | Caches tameable entities owners to avoid constant lookups against data watchers. If mods 
+  | cause issues, disable this.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-| Caches tameable entities owners to avoid constant lookups against data watchers. If mods 
-| cause issues, disable this.
+* **drops-pre-merge**
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+  | If ``true``, block item drops are pre-processed to avoid 
+  | having to spawn extra entities that will be merged post spawning. 
+  | Usually, Sponge is smart enough to determine when to attempt an item pre-merge 
+  | and when not to, however, in certain cases, some mods rely on items not being 
+  | pre-merged and actually spawned, in which case, the items will flow right through 
+  | without being merged.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**drops-pre-merge**
+* **enchantment-helper-leak-fix**
 
-| If 'true', block item drops are pre-processed to avoid 
-| having to spawn extra entities that will be merged post spawning. 
-| Usually, Sponge is smart enough to determine when to attempt an item pre-merge 
-| and when not to, however, in certain cases, some mods rely on items not being 
-| pre-merged and actually spawned, in which case, the items will flow right through 
-| without being merged.
+  | If ``true``, provides a fix for possible leaks through
+  | Minecraft's enchantment helper code that can leak
+  | entity and world references without much interaction
+  | Forge native (so when running SpongeForge implementation)
+  | has a similar patch, but Sponge's patch works a little harder
+  | at it, but Vanilla (SpongeVanilla implementation) does NOT
+  | have any of the patch, leading to the recommendation that this
+  | patch is enabled ``for sure`` when using SpongeVanilla implementation.
+  | See https://bugs.mojang.com/browse/MC-``128547`` for more information.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **faster-thread-checks**
 
-**enchantment-helper-leak-fix**
+  | If ``true``, allows for Sponge to make better assumptinos on single threaded
+  | operations with relation to various checks for server threaded operations.
+  | This is default to true due to Sponge being able to precisely inject when
+  | the server thread is available. This should make an already fast operation
+  | much faster for better thread checks to ensure stability of sponge's systems.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-| If 'true', provides a fix for possible leaks through
-| Minecraft's enchantment helper code that can leak
-| entity and world references without much interaction
-| Forge native (so when running SpongeForge implementation)
-| has a similar patch, but Sponge's patch works a little harder
-| at it, but Vanilla (SpongeVanilla implementation) does NOT
-| have any of the patch, leading to the recommendation that this
-| patch is enabled "for sure" when using SpongeVanilla implementation.
-| See https://bugs.mojang.com/browse/MC-128547 for more information.
+* **map-optimization**
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+  | If ``true``, re-writes the incredibly inefficient Vanilla Map code.
+  | This yields enormous performance enhancements when using many maps, but has a tiny chance of breaking mods that invasively modify Vanilla.It is strongly reccomended to keep this on, unless explicitly advised otherwise by a Sponge developer
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**faster-thread-checks**
+* **panda-redstone**
 
-| If 'true', allows for Sponge to make better assumptinos on single threaded
-| operations with relation to various checks for server threaded operations.
-| This is default to true due to Sponge being able to precisely inject when
-| the server thread is available. This should make an already fast operation
-| much faster for better thread checks to ensure stability of sponge's systems.
+  | If ``true``, uses Panda4494's redstone implementation which improves performance. 
+  | See https://bugs.mojang.com/browse/MC-``11193`` for more information. 
+  | **Note**: This optimization has a few issues which are explained in the bug report.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+* **structure-saving**
 
-**map-optimization**
+  | Handles structures that are saved to disk. Certain structures can take up large amounts 
+  | of disk space for very large maps and the data for these structures is only needed while the 
+  | world around them is generating. Disabling saving of these structures can save disk space and 
+  | time during saves if your world is already fully generated. 
+  | **Warning**: disabling structure saving will break the vanilla locate command.
+  | **Type:** :ref:`StructureSaveCategory<ConfigType_StructureSaveCategory>`
+  |
 
-| If 'true', re-writes the incredibly inefficient Vanilla Map code.
-| This yields enormous performance enhancements when using many maps, but has a tiny chance of breaking mods that invasively modify Vanilla.It is strongly reccomended to keep this on, unless explicitly advised otherwise by a Sponge developer
+.. _ConfigType_PhaseTrackerCategory:
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+PhaseTrackerCategory
+====================
 
-**panda-redstone**
+* **capture-async-spawning-entities**
 
-| If 'true', uses Panda4494's redstone implementation which improves performance. 
-| See https://bugs.mojang.com/browse/MC-11193 for more information. 
-| Note: This optimization has a few issues which are explained in the bug report.
+  | If set to ``true``, when a mod or plugin attempts to spawn an entity 
+  | off the main server thread, Sponge will automatically 
+  | capture said entity to spawn it properly on the main 
+  | server thread. The catch to this is that some mods are 
+  | not considering the consequences of spawning an entity 
+  | off the server thread, and are unaware of potential race 
+  | conditions they may cause. If this is set to false, 
+  | Sponge will politely ignore the entity being spawned, 
+  | and emit a warning about said spawn anyways.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **generate-stacktrace-per-phase**
 
-**structure-saving**
+  | If ``true``, more thorough debugging for PhaseStates 
+  | such that a StackTrace is created every time a PhaseState 
+  | switches, allowing for more fine grained troubleshooting 
+  | in the cases of runaway phase states. Note that this is 
+  | not extremely performant and may have some associated costs 
+  | with generating the stack traces constantly.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+* **max-block-processing-depth**
+
+  | The maximum number of times to recursively process transactions in a single phase.
+  | Some mods may interact badly with Sponge's block capturing system, causing Sponge to
+  | end up capturing block transactions every time it tries to process an existing batch.
+  | Due to the recursive nature of the depth-first processing that Sponge uses to handle block transactions,
+  | this can result in a stack overflow, which causes us to lose all infomration about the original cause of the issue.
+  | To prevent a stack overflow, Sponge tracks the current processing depth, and aborts processing when it exceeds
+  | this threshold.
+  | The default value should almost always work properly -  it's unlikely you'll ever have to change it.
+  | **Type:** ``int``
+  | **Default:** ``100``
+  |
+
+* **maximum-printed-runaway-counts**
+
+  | If verbose is not enabled, this restricts the amount of 
+  | runaway phase state printouts, usually happens on a server 
+  | where a PhaseState is not completing. Although rare, it should 
+  | never happen, but when it does, sometimes it can continuously print 
+  | more and more. This attempts to placate that while a fix can be worked on 
+  | to resolve the runaway. If verbose is enabled, they will always print.
+  | **Type:** ``int``
+  | **Default:** ``3``
+  |
+
+* **verbose**
+
+  | If ``true``, the phase tracker will print out when there are too many phases 
+  | being entered, usually considered as an issue of phase re-entrance and 
+  | indicates an unexpected issue of tracking phases not to complete. 
+  | If this is not reported yet, please report to Sponge. If it has been 
+  | reported, you may disable this.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **verbose-errors**
+
+  | If ``true``, the phase tracker will dump extra information about the current phases 
+  | when certain non-PhaseTracker related exceptions occur. This is usually not necessary, as the information 
+  | in the exception itself can normally be used to determine the cause of the issue
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
+
+.. _ConfigType_PlayerBlockTracker:
+
+PlayerBlockTracker
+==================
+
+* **block-blacklist**
+
+  | Block IDs that will be blacklisted for player block placement tracking.
+  | **Type:** ``List<String>``
+  |
+
+* **enabled**
+
+  | If ``true``, adds player tracking support for block positions. 
+  | **Note**: This should only be disabled if you do not care who caused a block to change.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+.. _ConfigType_SpawnerCategory:
+
+SpawnerCategory
+===============
+
+| Used to control spawn limits around players. 
+| **Note**: The radius uses the lower value of mob spawn range and server's view distance.
+|
+
+* **spawn-limit-ambient**
+
+  | The number of ambients the spawner can potentially spawn around a player.
+  | **Type:** ``int``
+  | **Default:** ``15``
+  |
+
+* **spawn-limit-animal**
+
+  | The number of animals the spawner can potentially spawn around a player.
+  | **Type:** ``int``
+  | **Default:** ``15``
+  |
+
+* **spawn-limit-aquatic**
+
+  | The number of aquatics the spawner can potentially spawn around a player.
+  | **Type:** ``int``
+  | **Default:** ``5``
+  |
+
+* **spawn-limit-monster**
+
+  | The number of monsters the spawner can potentially spawn around a player.
+  | **Type:** ``int``
+  | **Default:** ``70``
+  |
+
+* **tick-rate-ambient**
+
+  | The ambient spawning tick rate. Default: ``400``
+  | **Type:** ``int``
+  | **Default:** ``400``
+  |
+
+* **tick-rate-animal**
+
+  | The animal spawning tick rate. Default: ``400``
+  | **Type:** ``int``
+  | **Default:** ``400``
+  |
+
+* **tick-rate-aquatic**
+
+  | The aquatic spawning tick rate. Default: ``400``
+  | **Type:** ``int``
+  | **Default:** ``400``
+  |
+
+* **tick-rate-monster**
+
+  | The monster spawning tick rate. Default: ``1``
+  | **Type:** ``int``
+  | **Default:** ``1``
+  |
+
+.. _ConfigType_SqlCategory:
+
+SqlCategory
+===========
+
+| Configuration options related to the Sql service, including connection aliases etc
+|
+
+* **aliases**
+
+  | Aliases for SQL connections, in the format jdbc:protocol://[username[:password]@]host/database
+  | **Type:** ``Map<String, String>``
+  |
+
+.. _ConfigType_StructureModCategory:
+
+StructureModCategory
+====================
+
+| Per-mod overrides. Refer to the minecraft default mod for example.
+|
+
+* **enabled**
+
+  | If ``false``, this mod will never save its structures.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **structures**
+
+  | **Type:** ``Map<String, Boolean>``
+  |
+
+.. _ConfigType_StructureSaveCategory:
+
+StructureSaveCategory
+=====================
 
 | Handles structures that are saved to disk. Certain structures can take up large amounts 
 | of disk space for very large maps and the data for these structures is only needed while the 
 | world around them is generating. Disabling saving of these structures can save disk space and 
 | time during saves if your world is already fully generated. 
-| Warning: disabling structure saving will break the vanilla locate command.
+| **Warning**: disabling structure saving will break the vanilla locate command.
+|
 
-* **Type:** ``StructureSaveCategory``
+* **auto-populate**
 
-PlayerBlockTracker
-==================
+  | If ``true``, newly discovered structures will be added to this config with a default value.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**block-blacklist**
+* **enabled**
 
-| Block IDs that will be blacklisted for player block placement tracking.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``List<String>``
+* **mods**
 
-**enabled**
+  | Per-mod overrides. Refer to the minecraft default mod for example.
+  | **Type:** :ref:`Map\<String, StructureModCategory><ConfigType_StructureModCategory>`
+  |
 
-| If 'true', adds player tracking support for block positions. 
-| Note: This should only be disabled if you do not care who caused a block to change.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-SpawnerCategory
-===============
-
-**spawn-limit-ambient**
-
-| The number of ambients the spawner can potentially spawn around a player.
-
-* **Type:** ``int``
-* **Default:** ``15``
-
-**spawn-limit-animal**
-
-| The number of animals the spawner can potentially spawn around a player.
-
-* **Type:** ``int``
-* **Default:** ``15``
-
-**spawn-limit-aquatic**
-
-| The number of aquatics the spawner can potentially spawn around a player.
-
-* **Type:** ``int``
-* **Default:** ``5``
-
-**spawn-limit-monster**
-
-| The number of monsters the spawner can potentially spawn around a player.
-
-* **Type:** ``int``
-* **Default:** ``70``
-
-**tick-rate-ambient**
-
-| The ambient spawning tick rate. Default: 400
-
-* **Type:** ``int``
-* **Default:** ``400``
-
-**tick-rate-animal**
-
-| The animal spawning tick rate. Default: 400
-
-* **Type:** ``int``
-* **Default:** ``400``
-
-**tick-rate-aquatic**
-
-| The aquatic spawning tick rate. Default: 400
-
-* **Type:** ``int``
-* **Default:** ``400``
-
-**tick-rate-monster**
-
-| The monster spawning tick rate. Default: 1
-
-* **Type:** ``int``
-* **Default:** ``1``
-
-SqlCategory
-===========
-
-**aliases**
-
-| Aliases for SQL connections, in the format jdbc:protocol://[username[:password]@]host/database
-
-* **Type:** ``Map<String, String>``
+.. _ConfigType_TeleportHelperCategory:
 
 TeleportHelperCategory
 ======================
 
-**force-blacklist**
+| Blocks to blacklist for safe teleportation.
+|
 
-| If 'true', this blacklist will always be respected, otherwise, plugins can choose whether 
-| or not to respect it.
+* **force-blacklist**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | If ``true``, this blacklist will always be respected, otherwise, plugins can choose whether 
+  | or not to respect it.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**unsafe-body-block-ids**
+* **unsafe-body-block-ids**
 
-| Block IDs that are listed here will not be selected by Sponge's safe teleport routine as 
-| a safe block for players to warp into. 
-| You should only list blocks here that are incorrectly selected, solid blocks that prevent 
-| movement are automatically excluded.
+  | Block IDs that are listed here will not be selected by Sponge's safe teleport routine as 
+  | a safe block for players to warp into. 
+  | You should only list blocks here that are incorrectly selected, solid blocks that prevent 
+  | movement are automatically excluded.
+  | **Type:** ``List<String>``
+  |
 
-* **Type:** ``List<String>``
+* **unsafe-floor-block-ids**
 
-**unsafe-floor-block-ids**
+  | Block IDs that are listed here will not be selected by Sponge's safe 
+  | teleport routine as a safe floor block.
+  | **Type:** ``List<String>``
+  |
 
-| Block IDs that are listed here will not be selected by Sponge's safe 
-| teleport routine as a safe floor block.
-
-* **Type:** ``List<String>``
+.. _ConfigType_TileEntityActivationCategory:
 
 TileEntityActivationCategory
 ============================
 
-**auto-populate**
+* **auto-populate**
 
-| If 'true', newly discovered tileentities will be added to this config with default settings.
+  | If ``true``, newly discovered tileentities will be added to this config with default settings.
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+* **default-block-range**
 
-**default-block-range**
+  | Default activation block range used for all tileentities unless overridden.
+  | **Type:** ``int``
+  | **Default:** ``64``
+  |
 
-| Default activation block range used for all tileentities unless overridden.
+* **default-tick-rate**
 
-* **Type:** ``int``
-* **Default:** ``64``
+  | Default tick rate used for all tileentities unless overridden.
+  | **Type:** ``int``
+  | **Default:** ``1``
+  |
 
-**default-tick-rate**
+* **mods**
 
-| Default tick rate used for all tileentities unless overridden.
+  | Per-mod overrides. Refer to the minecraft default mod for example.
+  | **Type:** :ref:`Map\<String, TileEntityActivationModCategory><ConfigType_TileEntityActivationModCategory>`
+  |
 
-* **Type:** ``int``
-* **Default:** ``1``
+.. _ConfigType_TileEntityActivationModCategory:
 
-**mods**
+TileEntityActivationModCategory
+===============================
 
 | Per-mod overrides. Refer to the minecraft default mod for example.
+|
 
-* **Type:** ``Map<String, TileEntityActivationModCategory>``
+* **block-range**
+
+  | **Type:** ``Map<String, Integer>``
+  |
+
+* **default-block-range**
+
+  | **Type:** ``Integer``
+  |
+
+* **default-tick-rate**
+
+  | **Type:** ``Integer``
+  |
+
+* **enabled**
+
+  | If ``false``, tileentity activation rules for this mod will be ignored and always tick.
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
+
+* **tick-rate**
+
+  | **Type:** ``Map<String, Integer>``
+  |
+
+.. _ConfigType_TimingsCategory:
 
 TimingsCategory
 ===============
 
-**enabled**
+* **enabled**
 
-* **Type:** ``boolean``
-* **Default:** ``true``
+  | **Type:** ``boolean``
+  | **Default:** ``true``
+  |
 
-**hidden-config-entries**
+* **hidden-config-entries**
 
-* **Type:** ``List<String>``
+  | **Type:** ``List<String>``
+  |
 
-**history-interval**
+* **history-interval**
 
-* **Type:** ``int``
-* **Default:** ``300``
+  | **Type:** ``int``
+  | **Default:** ``300``
+  |
 
-**history-length**
+* **history-length**
 
-* **Type:** ``int``
-* **Default:** ``3600``
+  | **Type:** ``int``
+  | **Default:** ``3600``
+  |
 
-**server-name-privacy**
+* **server-name-privacy**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
-**verbose**
+* **verbose**
 
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-GlobalWorldCategory
-===================
-
-**auto-player-save-interval**
-
-| The auto-save tick interval used when saving global player data. (Default: 900) 
-| Note: 20 ticks is equivalent to 1 second. Set to 0 to disable.
-
-* **Type:** ``int``
-* **Default:** ``900``
-
-**auto-save-interval**
-
-| The auto-save tick interval used to save all loaded chunks in a world. 
-| Set to 0 to disable. (Default: 900) 
-| Note: 20 ticks is equivalent to 1 second.
-
-* **Type:** ``int``
-* **Default:** ``900``
-
-**chunk-gc-load-threshold**
-
-| The number of newly loaded chunks before triggering a forced cleanup. 
-| Note: When triggered, the loaded chunk threshold will reset and start incrementing. 
-| Disabled by default.
-
-* **Type:** ``int``
-* **Default:** ``0``
-
-**chunk-gc-tick-interval**
-
-| The tick interval used to cleanup all inactive chunks that have leaked in a world. 
-| Set to 0 to disable which restores vanilla handling. (Default: 600)
-
-* **Type:** ``int``
-* **Default:** ``600``
-
-**chunk-unload-delay**
-
-| The number of seconds to delay a chunk unload once marked inactive. (Default: 15) 
-| Note: This gets reset if the chunk becomes active again.
-
-* **Type:** ``int``
-* **Default:** ``15``
-
-**deny-chunk-requests**
-
-| If 'true', any request for a chunk not currently loaded will be denied (exceptions apply 
-| for things like world gen and player movement). 
-| Warning: As this is an experimental setting for performance gain, if you encounter any issues 
-| then we recommend disabling it.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**flowing-lava-decay**
-
-| Lava behaves like vanilla water when source block is removed
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**gameprofile-lookup-batch-size**
-
-| The amount of GameProfile requests to make against Mojang's session server. (Default: 1) 
-| Note: Mojang accepts a maximum of 600 requests every 10 minutes from a single IP address. 
-| If you are running multiple servers behind the same IP, it is recommended to raise the 'gameprofile-task-interval' setting  
-| in order to compensate for the amount requests being sent. 
-| Finally, if set to 0 or less, the default batch size will be used. 
-| For more information visit http://wiki.vg/Mojang_API
-
-* **Type:** ``int``
-* **Default:** ``1``
-
-**gameprofile-lookup-task-interval**
-
-| The interval, in seconds, used by the GameProfileQueryTask to process queued GameProfile requests. (Default: 4) 
-| Note: This setting should be raised if you experience the following error: 
-| "The client has sent too many requests within a certain amount of time". 
-| Finally, if set to 0 or less, the default interval will be used.
-
-* **Type:** ``int``
-* **Default:** ``4``
-
-**generate-spawn-on-load**
-
-| If 'true', this world will generate its spawn the moment its loaded.
-
-* **Type:** ``Boolean``
-
-**infinite-water-source**
-
-| Vanilla water source behavior - is infinite
-
-* **Type:** ``boolean``
-* **Default:** ``false``
-
-**invalid-lookup-uuids**
-
-| The list of uuid's that should never perform a lookup against Mojang's session server. 
-| Note: If you are using SpongeForge, make sure to enter any mod fake player's UUID to this list.
-
-* **Type:** ``List<UUID>``
-
-**item-merge-radius**
-
-| The defined merge radius for Item entities such that when two items are 
-| within the defined radius of each other, they will attempt to merge. Usually, 
-| the default radius is set to 0.5 in Vanilla, however, for performance reasons 
-| 2.5 is generally acceptable. 
-| Note: Increasing the radius higher will likely cause performance degradation 
-| with larger amount of items as they attempt to merge and search nearby 
-| areas for more items. Setting to a negative value is not supported!
-
-* **Type:** ``double``
-* **Default:** ``2.5``
-
-**keep-spawn-loaded**
-
-| If 'true', this worlds spawn will remain loaded with no players.
-
-* **Type:** ``Boolean``
-* **Default:** ``true``
-
-**leaf-decay**
-
-| If 'true', natural leaf decay is allowed.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**load-on-startup**
-
-| If 'true', this world will load on startup.
-
-* **Type:** ``Boolean``
-* **Default:** ``true``
-
-**max-chunk-unloads-per-tick**
-
-| The maximum number of queued unloaded chunks that will be unloaded in a single tick. 
-| Note: With the chunk gc enabled, this setting only applies to the ticks 
-| where the gc runs (controlled by 'chunk-gc-tick-interval') 
-| Note: If the maximum unloads is too low, too many chunks may remain 
-| loaded on the world and increases the chance for a drop in tps. (Default: 100)
-
-* **Type:** ``int``
-* **Default:** ``100``
-
-**mob-spawn-range**
-
-| Specifies the radius (in chunks) of where creatures will spawn. 
-| This value is capped to the current view distance setting in server.properties
-
-* **Type:** ``int``
-* **Default:** ``4``
-
-**portal-agents**
-
-| A list of all detected portal agents used in this world. 
-| In order to override, change the target world name to any other valid world. 
-| Note: If world is not found, it will fallback to default.
-
-* **Type:** ``Map<String, String>``
-
-**pvp-enabled**
-
-| If 'true', this world will allow PVP combat.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**view-distance**
-
-| Override world distance per world/dimension 
-| The value must be greater than or equal to 3 and less than or equal to 32 
-| The server-wide view distance will be used when the value is -1.
-
-* **Type:** ``int``
-* **Default:** ``-1``
-
-**weather-ice-and-snow**
-
-| If 'true', natural formation of ice and snow in supported biomes will be allowed.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**weather-thunder**
-
-| If 'true', thunderstorms will be initiated in supported biomes.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
-**world-enabled**
-
-| If 'true', this world will be registered.
-
-* **Type:** ``boolean``
-* **Default:** ``true``
-
+  | **Type:** ``boolean``
+  | **Default:** ``false``
+  |
 
 
 ------------------------------------------------------------------------------------------------------------

--- a/source/server/getting-started/configuration/sponge-conf.rst
+++ b/source/server/getting-started/configuration/sponge-conf.rst
@@ -345,8 +345,8 @@ EigenRedstone
 * **enabled**
 
   | If ``true``, uses theosib's redstone implementation which improves performance. 
-  | See https://bugs.mojang.com/browse/MC-``11193`` and 
-  |      https://bugs.mojang.com/browse/MC-``81098`` for more information. 
+  | See https://bugs.mojang.com/browse/MC-11193 and 
+  |      https://bugs.mojang.com/browse/MC-81098 for more information. 
   | **Note**: We cannot guarantee compatibility with mods. Use at your discretion.
   | **Type:** ``boolean``
   | **Default:** ``false``
@@ -792,7 +792,7 @@ GlobalWorld
 
   | Override world distance per world/dimension 
   | The value must be greater than or equal to ``3`` and less than or equal to ``32`` 
-  | The server-wide view distance will be used when the value is ``1``.
+  | The server-wide view distance will be used when the value is ``-1``.
   | **Type:** ``int``
   | **Default:** ``-1``
   |
@@ -1141,7 +1141,7 @@ Optimization
   | at it, but Vanilla (SpongeVanilla implementation) does NOT
   | have any of the patch, leading to the recommendation that this
   | patch is enabled ``for sure`` when using SpongeVanilla implementation.
-  | See https://bugs.mojang.com/browse/MC-``128547`` for more information.
+  | See https://bugs.mojang.com/browse/MC-128547 for more information.
   | **Type:** ``boolean``
   | **Default:** ``true``
   |
@@ -1183,7 +1183,7 @@ Optimization
 * **panda-redstone**
 
   | If ``true``, uses Panda4494's redstone implementation which improves performance. 
-  | See https://bugs.mojang.com/browse/MC-``11193`` for more information. 
+  | See https://bugs.mojang.com/browse/MC-11193 for more information. 
   | **Note**: This optimization has a few issues which are explained in the bug report. 
   | We strongly recommend using eigen redstone over this implementation as this will
   | be removed in a future release.

--- a/tools/README.md
+++ b/tools/README.md
@@ -5,3 +5,4 @@ This package contains a number of tools that help maintaining the docs.
 
 * [Javadoc-Checker](javadoc-checker) - Checks imports and javadoc-references
 * [Code-Checker](code-checker) - Extracts code blocks and wraps them in proper classes
+* [Config-Lister](config-lister) - A library that generates a page that explains the configuration options in Sponge.

--- a/tools/code-checker/pom.xml
+++ b/tools/code-checker/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/tools/config-lister/LICENSE.txt
+++ b/tools/config-lister/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) SpongePowered <https://www.spongepowered.org>
+Copyright (c) contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/config-lister/README.md
+++ b/tools/config-lister/README.md
@@ -12,7 +12,7 @@ Requirements
 Usage
 -----
 
-1. Update the SpongeCommon dependendy to the latest recommended release in the pom.
+1. Update the SpongeCommon dependency to the latest recommended release in the pom.
 2. And then run the generated jar file:
 
 ````bash

--- a/tools/config-lister/README.md
+++ b/tools/config-lister/README.md
@@ -1,0 +1,29 @@
+Config-Lister
+=============
+
+A library that generates a page that explains the configuration options in Sponge.
+
+Requirements
+------------
+
+* Java 8
+* Maven 3.5
+
+Usage
+-----
+
+1. Update the SpongeCommon dependendy to the latest recommended release in the pom.
+2. And then run the generated jar file:
+
+````bash
+java -jar config-lister.jar
+````
+
+or run the maven command:
+
+````bash
+mvn exec:java
+````
+
+3. Copy the output from your console into `source/server/getting-started/configuration/sponge-conf.rst`  
+   and update the reference to the SpongeCommon version on that page

--- a/tools/config-lister/pom.xml
+++ b/tools/config-lister/pom.xml
@@ -25,8 +25,8 @@
     </organization>
 
     <properties>
-        <sponge.api.version>7.1.0</sponge.api.version>
-        <sponge.common.version>1.12.2-7.1.9</sponge.common.version>
+        <sponge.api.version>7.2.0</sponge.api.version>
+        <sponge.common.version>1.12.2-7.2.0</sponge.common.version>
 
         <java.version>8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/tools/config-lister/pom.xml
+++ b/tools/config-lister/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.spongepowered.docs.tools</groupId>
+    <artifactId>config-lister</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <name>SpongeDocs global.conf Documenation Generator</name>
+    <description>A library that generates the description for the config options in the global.conf file.</description>
+    <url>https://docs.spongepowered.org/</url>
+    <inceptionYear>2020</inceptionYear>
+
+    <licenses>
+        <license>
+            <name>The MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <organization>
+        <name>SpongePowered</name>
+        <url>https://www.spongepowered.org/</url>
+    </organization>
+
+    <properties>
+        <sponge.api.version>7.1.0</sponge.api.version>
+        <sponge.common.version>7.1.0</sponge.common.version>
+
+        <java.version>8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+
+        <charset>UTF-8</charset>
+        <project.reporting.outputEncoding>${charset}</project.reporting.outputEncoding>
+        <project.build.sourceEncoding>${charset}</project.build.sourceEncoding>
+
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>sponge</id>
+            <url>https://repo.spongepowered.org/maven</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spongepowered</groupId>
+            <artifactId>spongeapi</artifactId>
+            <version>${sponge.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.spongepowered</groupId>
+            <artifactId>spongecommon</artifactId>
+            <version>${sponge.common.version}</version>
+            <classifier>dev</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>clean package exec:java</defaultGoal>
+        <resources>
+            <resource>
+                <directory>.</directory>
+                <includes>
+                    <include>LICENSE.txt</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <build-timestamp>${maven.build.timestamp}</build-timestamp>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tools/config-lister/pom.xml
+++ b/tools/config-lister/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <sponge.api.version>7.1.0</sponge.api.version>
-        <sponge.common.version>7.1.0</sponge.common.version>
+        <sponge.common.version>1.12.2-7.1.9</sponge.common.version>
 
         <java.version>8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/tools/config-lister/src/main/java/net/minecraft/launchwrapper/Launch.java
+++ b/tools/config-lister/src/main/java/net/minecraft/launchwrapper/Launch.java
@@ -1,0 +1,7 @@
+package net.minecraft.launchwrapper;
+
+public class Launch {
+
+    public static LaunchClassLoader classLoader = new LaunchClassLoader();
+
+}

--- a/tools/config-lister/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
+++ b/tools/config-lister/src/main/java/net/minecraft/launchwrapper/LaunchClassLoader.java
@@ -1,0 +1,9 @@
+package net.minecraft.launchwrapper;
+
+public class LaunchClassLoader {
+
+    public byte[] getClassBytes(final String name) {
+        return null;
+    }
+
+}

--- a/tools/config-lister/src/main/java/net/minecraft/launchwrapper/package-info.java
+++ b/tools/config-lister/src/main/java/net/minecraft/launchwrapper/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Helper code to avoid NoClassDefFoundError in
+ * {@link org.spongepowered.common.config.category.WorldCategory#WorldCategory()}.
+ */
+package net.minecraft.launchwrapper;

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -31,13 +31,14 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.commons.lang3.StringUtils;
 import org.spongepowered.common.config.type.GlobalConfig;
@@ -54,6 +55,7 @@ public class ConfigLister {
             .add(boolean.class)
             .add(Boolean.class)
             .add(int.class)
+            .add(Integer.class)
             .add(double.class)
             .add(String.class)
             .add(UUID.class)
@@ -63,32 +65,52 @@ public class ConfigLister {
     private static final char[] HEADLINE_LEVELS = { '#', '*', '=', '-', '^', '\"' };
     private static final char TYPE_HEADLINE_LEVEL = HEADLINE_LEVELS[2];
 
+    /**
+     * Writes the documentation to sysout.
+     *
+     * @param args No args.
+     */
     public static void main(final String... args) {
 
-        final Set<Class<?>> configClasses = scanForNestedTypes(GlobalConfig.class);
+        final Map<Class<?>, String> configClasses = scanForNestedTypes(GlobalConfig.class);
         final StringBuilder sb = new StringBuilder();
-        for (final Class<?> clazz : configClasses) {
-            writeDocumentation(clazz, sb);
+        writeDocumentation(GlobalConfig.class, "The main configuration for Sponge: ``global.conf``", sb);
+        for (final Entry<Class<?>, String> entry : configClasses.entrySet()) {
+            writeDocumentation(entry.getKey(), entry.getValue(), sb);
         }
         System.out.println(sb);
     }
 
-    public static Set<Class<?>> scanForNestedTypes(final Class<?> clazz) {
-        final Set<Class<?>> result = new LinkedHashSet<>();
-        result.add(clazz);
-        final Queue<Class<?>> queue = new ConcurrentLinkedQueue<>();
-        queue.add(clazz);
-        for (final Class<?> current : queue) {
+    /**
+     * Scans for nested configuration types.
+     *
+     * @param clazz The class to scan for nested types.
+     * @return A sorted map containing all nested configuration classes, with their
+     *         primary description.
+     */
+    public static Map<Class<?>, String> scanForNestedTypes(final Class<?> clazz) {
+        final Map<Class<?>, String> result = new TreeMap<>(Comparator.comparing(Class::getSimpleName));
+        final Queue<Class<?>> queue = new LinkedList<>();
+        Class<?> current = clazz;
+        do {
             for (final Field field : getAllFieldsFrom(current)) {
+                final String comment = extractComment(field);
                 final Class<?> fieldClass = extractSingularType(field.getGenericType());
-                if (!DATA_CLASSES.contains(fieldClass) && result.add(fieldClass)) {
-                    queue.add(current);
+                if (!DATA_CLASSES.contains(fieldClass) && !result.containsKey(fieldClass)) {
+                    result.put(fieldClass, comment);
+                    queue.add(fieldClass);
                 }
             }
-        }
+        } while ((current = queue.poll()) != null);
         return result;
     }
 
+    /**
+     * Gets all fields for the given class.
+     *
+     * @param clazz The class to get the fields from.
+     * @return A sorted set containing the fields of the given class.
+     */
     public static Set<Field> getAllFieldsFrom(final Class<?> clazz) {
         if (Object.class.equals(clazz)) {
             return Collections.emptySet();
@@ -103,10 +125,28 @@ public class ConfigLister {
         return fields;
     }
 
+    /**
+     * Extracts the singular type of the given type. If the given type represents a
+     * {@link Collection} then it will return the type of the collection. If the
+     * given type represents a {@link Map} then it will return the type of the
+     * value. Otherwise it will return the rawtype of the given type.
+     *
+     * @param type The type to extract the singular type from.
+     * @return The singular type of the given type.
+     */
     public static Class<?> extractSingularType(final Type type) {
         return extractSingularType(TypeToken.of(type));
     }
 
+    /**
+     * Extracts the singular type of the given type. If the given type represents a
+     * {@link Collection} then it will return the type of the collection. If the
+     * given type represents a {@link Map} then it will return the type of the
+     * value. Otherwise it will return the rawtype of the given type.
+     *
+     * @param type The type to extract the singular type from.
+     * @return The singular type of the given type.
+     */
     public static Class<?> extractSingularType(final TypeToken<?> type) {
         if (type.isSubtypeOf(Collection.class)) {
             return type.resolveType(Collection.class.getTypeParameters()[0]).getRawType();
@@ -117,6 +157,12 @@ public class ConfigLister {
         return type.getRawType();
     }
 
+    /**
+     * Extracts the name of the field.
+     *
+     * @param field The field to extract the name from.
+     * @return The defined name or the derived name of the field.
+     */
     public static String extractName(final Field field) {
         final Setting setting = field.getAnnotation(Setting.class);
         if (setting.value().isEmpty()) {
@@ -125,59 +171,126 @@ public class ConfigLister {
         return setting.value();
     }
 
+    /**
+     * Extracts the comment from the given field.
+     *
+     * @param field The field to extract the comment from.
+     * @return The processed comment for the given field or null.
+     */
     public static String extractComment(final Field field) {
         final Setting setting = field.getAnnotation(Setting.class);
         if (setting.comment().isEmpty()) {
             return null;
         }
-        return setting.comment().trim().replace("\n", "\n| ");
+        return setting.comment().strip()
+                .replaceAll(" ?\\(Default: [^\\)]+\\)", "") // Remove default value, we already have that
+                .replaceAll("\n\n+", "\n") // Remove empty lines
+                .replace("\"", "``") // " -> ``
+                .replaceAll("(\\W|^)'(.*)'(\\W|$)", "$1``$2``$3") // 'highlighted' -> ``highlighted``, ignore "it's"
+                .replaceAll("(\\W|^)-?([0-9]*\\.?[0-9]+)(\\W|$)", "$1``$2``$3") // 1 -> ``1``, ignore 1x1
+                .replaceAll("\n?(Note|Warning|WARNING):", "\n**$1**:"); // Highlight keywords
     }
 
-    public static void writeDocumentation(final Class<?> clazz, final StringBuilder sb) {
+    /**
+     * Writes the documentation for the given class to the given string builder.
+     *
+     * @param clazz The class to write the documentation for.
+     * @param classComment The comment for the class. Can be null.
+     * @param sb The string builder to write the documentation to.
+     */
+    public static void writeDocumentation(final Class<?> clazz, final String classComment, final StringBuilder sb) {
         final Object defaultInstance = createDefaultInstance(clazz);
         final String simpleName = clazz.getSimpleName();
-        writeHeadline(simpleName, TYPE_HEADLINE_LEVEL, sb);
+        // Class header
+        writeTypeHeadline(simpleName, TYPE_HEADLINE_LEVEL, sb);
         sb.append('\n');
+        if (classComment != null) {
+            sb.append("| ").append(classComment
+                    .replace("\n", "\n| ")).append("\n|\n\n");
+        }
+
+        // Fields
         for (final Field field : getAllFieldsFrom(clazz)) {
             final Type fieldType = field.getGenericType();
-            final boolean simpleDataClass = DATA_CLASSES.contains(field.getType());
+            final Class<?> singularType = extractSingularType(fieldType);
+
             final String comment = extractComment(field);
 
-            sb.append("**").append(extractName(field)).append("**\n");
+            // Field-Name
+            sb.append("* **").append(extractName(field)).append("**\n");
             sb.append('\n');
+            // Field-Comment
             if (comment != null) {
-                sb.append("| ").append(comment).append("\n\n");
+                sb.append("  | ").append(comment
+                        .replace("\n", "\n  | ")).append('\n');
             }
-            sb.append("* **Type:** ``").append(toText(fieldType)).append("``\n");
-            if (simpleDataClass) {
+            // Field-Type
+            if (DATA_CLASSES.contains(singularType)) {
+                // Simple type -> Just text
+                sb.append("  | **Type:** ``").append(toText(fieldType)).append("``\n");
+            } else {
+                // Nested type -> Generate link
+                sb.append("  | **Type:** :ref:`").append(toText(fieldType).replace("<", "\\<"))
+                        .append("<ConfigType_").append(singularType.getSimpleName()).append(">`\n");
+            }
+            // Field-Default
+            if (DATA_CLASSES.contains(field.getType())) {
                 final Object defaultValue = getDefaultValue(defaultInstance, field);
                 if (defaultValue != null) {
-                    sb.append("* **Default:** ``").append(defaultValue).append("``\n");
+                    sb.append("  | **Default:** ``").append(defaultValue).append("``\n");
                 }
             }
+            sb.append("  |\n");
             sb.append('\n');
         }
     }
 
-    private static void writeHeadline(final String simpleName, final char headlineLevel, final StringBuilder sb) {
+    /**
+     * Writes a headline for the given type.
+     *
+     * @param simpleName The simple name of the type to write.
+     * @param headlineLevel The headline level char to use.
+     * @param sb The string builder to write the headline to.
+     */
+    private static void writeTypeHeadline(final String simpleName, final char headlineLevel, final StringBuilder sb) {
+        sb.append(".. _ConfigType_").append(simpleName).append(":\n\n");
         sb.append(simpleName).append('\n');
         sb.append(StringUtils.repeat(headlineLevel, simpleName.length())).append('\n');
     }
 
-    private static Object createDefaultInstance(final Class<?> clazz) {
-        try {
-            return clazz.getConstructor().newInstance();
-        } catch (final Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
+    /**
+     * Converts the given type to its simple name, but retains generic parameters.
+     *
+     * @param type The type to convert.
+     * @return The simple name of the given type.
+     */
     private static String toText(final Type type) {
         return TypeToken.of(type).toString()
                 .replaceAll("[A-Za-z]+\\.", "");
     }
 
+    /**
+     * Create the default instance of the given class.
+     *
+     * @param clazz The class to create the default instance for.
+     * @return The newly created default instance.
+     */
+    private static Object createDefaultInstance(final Class<?> clazz) {
+        try {
+            return clazz.getConstructor().newInstance();
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the default value for the given field.
+     *
+     * @param defaultInstance The default instance to extract the default value
+     *            from. Can be null.
+     * @param field The field to extract the default value for.
+     * @return The default value for the given field or null.
+     */
     private static Object getDefaultValue(final Object defaultInstance, final Field field) {
         if (defaultInstance == null) {
             return null;

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -187,7 +187,7 @@ public class ConfigLister {
                 .replaceAll("\n\n+", "\n") // Remove empty lines
                 .replace("\"", "``") // " -> ``
                 .replaceAll("(\\W|^)'(.*)'(\\W|$)", "$1``$2``$3") // 'highlighted' -> ``highlighted``, ignore "it's"
-                .replaceAll("(\\W|^)-?([0-9]*\\.?[0-9]+)(\\W|$)", "$1``$2``$3") // 1 -> ``1``, ignore 1x1
+                .replaceAll("([^a-zA-Z0-9/]|^)-?([0-9]*\\.?[0-9]+)([^a-zA-Z0-9/]|$)", "$1``$2``$3") // 1 -> ``1``, ignore 1x1
                 .replaceAll("\n?(Note|Warning|WARNING):", "\n**$1**:"); // Highlight keywords
     }
 

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -204,8 +204,9 @@ public class ConfigLister {
         writeTypeHeadline(toSimpleName(clazz), TYPE_HEADLINE_LEVEL, sb);
         sb.append('\n');
         if (classComment != null) {
-            sb.append("| ").append(classComment
-                    .replace("\n", "\n| ")).append("\n|\n\n");
+            sb.append("| ").append(classComment.replace("\n", "\n| ")).append('\n');
+            sb.append("|\n"); // Extra line to force some space between the end of this section and the next
+            sb.append('\n');
         }
 
         // Fields
@@ -239,7 +240,7 @@ public class ConfigLister {
                     sb.append("  | **Default:** ``").append(defaultValue).append("``\n");
                 }
             }
-            sb.append("  |\n");
+            sb.append("  |\n"); // Extra line to force some space between the end of this section and the next
             sb.append('\n');
         }
     }

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -200,9 +200,8 @@ public class ConfigLister {
      */
     public static void writeDocumentation(final Class<?> clazz, final String classComment, final StringBuilder sb) {
         final Object defaultInstance = createDefaultInstance(clazz);
-        final String simpleName = clazz.getSimpleName();
         // Class header
-        writeTypeHeadline(simpleName, TYPE_HEADLINE_LEVEL, sb);
+        writeTypeHeadline(toSimpleName(clazz), TYPE_HEADLINE_LEVEL, sb);
         sb.append('\n');
         if (classComment != null) {
             sb.append("| ").append(classComment
@@ -231,7 +230,7 @@ public class ConfigLister {
             } else {
                 // Nested type -> Generate link
                 sb.append("  | **Type:** :ref:`").append(toText(fieldType).replace("<", "\\<"))
-                        .append("<ConfigType_").append(singularType.getSimpleName()).append(">`\n");
+                        .append("<ConfigType_").append(toSimpleName(singularType)).append(">`\n");
             }
             // Field-Default
             if (DATA_CLASSES.contains(field.getType())) {
@@ -266,7 +265,13 @@ public class ConfigLister {
      */
     private static String toText(final Type type) {
         return TypeToken.of(type).toString()
-                .replaceAll("[A-Za-z]+\\.", "");
+                .replaceAll("[A-Za-z]+\\.", "") // Remove package names
+                .replaceAll("Category(\\W|$)", "$1"); // Remove confusing Category suffix
+    }
+
+    private static String toSimpleName(final Class<?> clazz) {
+        return clazz.getSimpleName()
+                .replaceAll("Category$", ""); // Remove confusing Category suffix
     }
 
     /**

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -186,7 +186,8 @@ public class ConfigLister {
                 .replaceAll(" ?\\(Default: [^\\)]+\\)", "") // Remove default value, we already have that
                 .replaceAll("\n\n+", "\n") // Remove empty lines
                 .replace("\"", "``") // " -> ``
-                .replaceAll("(\\W|^)'(.*)'(\\W|$)", "$1``$2``$3") // 'highlighted' -> ``highlighted``, ignore "it's"
+                .replaceAll("(^|\\W)'([^,']*)'(\\W|$)", "$1``$2``$3") // 'highlighted' -> ``highlighted``, ignore "it's"
+                .replaceAll("(^|\\W)'([^,']*)'s(\\W|$)", "$1``$2``\\\\s$3") // 'highlight's -> ``highlight``\s, ignore "it's"
                 .replaceAll("(^|[ \n\\(])(-?[0-9]+(?:\\.[0-9]+)?)([ \n\\)\\.]|$)", "$1``$2``$3") // 1 -> ``1``, ignore 1x1
                 .replaceAll("\n?(Note|Warning|WARNING):", "\n**$1**:"); // Highlight keywords
     }

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -376,11 +376,11 @@ public class ConfigLister {
         }
 
         String getName() {
-            return this.declaration == null ? ".." : extractName(this.declaration);
+            return extractName(this.declaration);
         }
 
         String getNameAsChild() {
-            final String name = extractName(this.declaration);
+            final String name = getName();
             if (ROOT_PLACEHOLDER.equals(name)) {
                 return toSimpleName(this);
             }

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -187,7 +187,7 @@ public class ConfigLister {
                 .replaceAll("\n\n+", "\n") // Remove empty lines
                 .replace("\"", "``") // " -> ``
                 .replaceAll("(\\W|^)'(.*)'(\\W|$)", "$1``$2``$3") // 'highlighted' -> ``highlighted``, ignore "it's"
-                .replaceAll("([^a-zA-Z0-9/]|^)-?([0-9]*\\.?[0-9]+)([^a-zA-Z0-9/]|$)", "$1``$2``$3") // 1 -> ``1``, ignore 1x1
+                .replaceAll("(^|[ \n\\(])(-?[0-9]+(?:\\.[0-9]+)?)([ \n\\)\\.]|$)", "$1``$2``$3") // 1 -> ``1``, ignore 1x1
                 .replaceAll("\n?(Note|Warning|WARNING):", "\n**$1**:"); // Highlight keywords
     }
 

--- a/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
+++ b/tools/config-lister/src/main/java/org/spongepowered/docs/tools/configlister/ConfigLister.java
@@ -1,0 +1,193 @@
+/**
+ * This file is part of ConfigLister, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.spongepowered.docs.tools.configlister;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.commons.lang3.StringUtils;
+import org.spongepowered.common.config.type.GlobalConfig;
+import org.spongepowered.common.util.IpSet;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.TypeToken;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+
+public class ConfigLister {
+
+    private static final Set<Class<?>> DATA_CLASSES = ImmutableSet.<Class<?>>builder()
+            .add(boolean.class)
+            .add(Boolean.class)
+            .add(int.class)
+            .add(double.class)
+            .add(String.class)
+            .add(UUID.class)
+            .add(IpSet.class)
+            .build();
+
+    private static final char[] HEADLINE_LEVELS = { '#', '*', '=', '-', '^', '\"' };
+    private static final char TYPE_HEADLINE_LEVEL = HEADLINE_LEVELS[2];
+
+    public static void main(final String... args) {
+
+        final Set<Class<?>> configClasses = scanForNestedTypes(GlobalConfig.class);
+        final StringBuilder sb = new StringBuilder();
+        for (final Class<?> clazz : configClasses) {
+            writeDocumentation(clazz, sb);
+        }
+        System.out.println(sb);
+    }
+
+    public static Set<Class<?>> scanForNestedTypes(final Class<?> clazz) {
+        final Set<Class<?>> result = new LinkedHashSet<>();
+        result.add(clazz);
+        final Queue<Class<?>> queue = new ConcurrentLinkedQueue<>();
+        queue.add(clazz);
+        for (final Class<?> current : queue) {
+            for (final Field field : getAllFieldsFrom(current)) {
+                final Class<?> fieldClass = extractSingularType(field.getGenericType());
+                if (!DATA_CLASSES.contains(fieldClass) && result.add(fieldClass)) {
+                    queue.add(current);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static Set<Field> getAllFieldsFrom(final Class<?> clazz) {
+        if (Object.class.equals(clazz)) {
+            return Collections.emptySet();
+        }
+        final Set<Field> fields = new TreeSet<>(Comparator.comparing(ConfigLister::extractName));
+        for (final Field field : clazz.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                fields.add(field);
+            }
+        }
+        fields.addAll(getAllFieldsFrom(clazz.getSuperclass()));
+        return fields;
+    }
+
+    public static Class<?> extractSingularType(final Type type) {
+        return extractSingularType(TypeToken.of(type));
+    }
+
+    public static Class<?> extractSingularType(final TypeToken<?> type) {
+        if (type.isSubtypeOf(Collection.class)) {
+            return type.resolveType(Collection.class.getTypeParameters()[0]).getRawType();
+        }
+        if (type.isSubtypeOf(Map.class)) {
+            return extractSingularType(type.resolveType(Map.class.getTypeParameters()[1]));
+        }
+        return type.getRawType();
+    }
+
+    public static String extractName(final Field field) {
+        final Setting setting = field.getAnnotation(Setting.class);
+        if (setting.value().isEmpty()) {
+            return field.getName();
+        }
+        return setting.value();
+    }
+
+    public static String extractComment(final Field field) {
+        final Setting setting = field.getAnnotation(Setting.class);
+        if (setting.comment().isEmpty()) {
+            return null;
+        }
+        return setting.comment().trim().replace("\n", "\n| ");
+    }
+
+    public static void writeDocumentation(final Class<?> clazz, final StringBuilder sb) {
+        final Object defaultInstance = createDefaultInstance(clazz);
+        final String simpleName = clazz.getSimpleName();
+        writeHeadline(simpleName, TYPE_HEADLINE_LEVEL, sb);
+        sb.append('\n');
+        for (final Field field : getAllFieldsFrom(clazz)) {
+            final Type fieldType = field.getGenericType();
+            final boolean simpleDataClass = DATA_CLASSES.contains(field.getType());
+            final String comment = extractComment(field);
+
+            sb.append("**").append(extractName(field)).append("**\n");
+            sb.append('\n');
+            if (comment != null) {
+                sb.append("| ").append(comment).append("\n\n");
+            }
+            sb.append("* **Type:** ``").append(toText(fieldType)).append("``\n");
+            if (simpleDataClass) {
+                final Object defaultValue = getDefaultValue(defaultInstance, field);
+                if (defaultValue != null) {
+                    sb.append("* **Default:** ``").append(defaultValue).append("``\n");
+                }
+            }
+            sb.append('\n');
+        }
+    }
+
+    private static void writeHeadline(final String simpleName, final char headlineLevel, final StringBuilder sb) {
+        sb.append(simpleName).append('\n');
+        sb.append(StringUtils.repeat(headlineLevel, simpleName.length())).append('\n');
+    }
+
+    private static Object createDefaultInstance(final Class<?> clazz) {
+        try {
+            return clazz.getConstructor().newInstance();
+        } catch (final Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private static String toText(final Type type) {
+        return TypeToken.of(type).toString()
+                .replaceAll("[A-Za-z]+\\.", "");
+    }
+
+    private static Object getDefaultValue(final Object defaultInstance, final Field field) {
+        if (defaultInstance == null) {
+            return null;
+        }
+        try {
+            field.setAccessible(true);
+            return field.get(defaultInstance);
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+}

--- a/tools/javadoc-checker/pom.xml
+++ b/tools/javadoc-checker/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
Supersedes #794 

The documentation is directly generated from the classes, so it contains the maximum amount of information. I also included the default value for the simple types.