### PR TITLE
Update notes on LagGoggle/TickCentral incompatibilties

### DIFF
--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -85,10 +85,11 @@ Just Enough IDs (JEID)
 - Solution: Update to version 1.0.3-54 or newer.
 
 LagGoggles/TickCentral
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 - Versions: All
-- Problem: Crash on startup (mixin conflict) or .
-- Solution: Due to the very invasive nature of these mods, it's hard for SpongeForge to run properly alongside them. Only use LagGoggles/TickCentral when you need to debug issues, and do not leave it on your server for production constant use.
+- Problem: Crash on startup (mixin conflict).
+- Solution: Due to the very invasive nature of these mods, SpongeForge cannot run properly alongside them. 
+  Only use these mods when you need to debug issues, and do not leave it on your server for production constant use.
 - Issues: https://github.com/SpongePowered/SpongeForge/issues/3171
 
 MystCraft

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -88,9 +88,7 @@ LagGoggles/TickCentral
 ~~~~~~~~~~~~~~~~~~~~~~
 - Versions: All
 - Problem: Crash on startup (mixin conflict).
-- Solution: Due to the very invasive nature of these mods, SpongeForge cannot run properly alongside them. 
-  Only use these mods when you need to debug issues, and do not leave it on your server for production constant use.
-- Issues: https://github.com/SpongePowered/SpongeForge/issues/3171
+- Solution: No compatibility at present. Choose one or the other.
 
 MystCraft
 ~~~~~~~~~

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -84,11 +84,12 @@ Just Enough IDs (JEID)
 - Problem: Crash on startup (mixin conflict).
 - Solution: Update to version 1.0.3-54 or newer.
 
-LagGoggles
+LagGoggles/TickCentral
 ~~~~~~~~~~
-- Versions: Older than 1.12.2-5.3-113
-- Problem: Crash on startup (mixin conflict).
-- Solution: Update to version 1.12.2-5.3-113 and install *TickCentral* core-mod.
+- Versions: All
+- Problem: Crash on startup (mixin conflict) or .
+- Solution: Due to the very invasive nature of these mods, it's hard for SpongeForge to run properly alongside them. Only use LagGoggles/TickCentral when you need to debug issues, and do not leave it on your server for production constant use.
+- Issues: https://github.com/SpongePowered/SpongeForge/issues/3171
 
 MystCraft
 ~~~~~~~~~


### PR DESCRIPTION
Due to constant issues with this set of mods, it's easier to just mark them as "avoid using when possible" and add relevant links. While there are times when you can have a working version, it's hit and miss. 

https://github.com/SpongePowered/SpongeForge/issues/3171 is a recent issue with their "new" solution to get around issues, and it is having issues. 