### PR TITLE
Change permission for base command in Child Command example

### DIFF
--- a/source/plugin/commands/childcommands.rst
+++ b/source/plugin/commands/childcommands.rst
@@ -51,7 +51,7 @@ The first alias supplied is the primary one and will appear in the usage message
     PluginContainer plugin = ...;
 
     CommandSpec mailCommandSpec = CommandSpec.builder()
-        .permission("myplugin.mail")
+        .permission("myplugin.mail.base")
         .description(Text.of("Send and receive mails"))
         .child(readCmd, "read", "r", "inbox")
         .child(sendCmd, "send", "s", "write")


### PR DESCRIPTION
The problem is that if the base command has the `myplugin.mail` and someone has that permission, they also have the `myplugin.mail.send` and `myplugin.mail.read` permissions, meaning they have the subcommands automatically. This changes that so they don't have those sub commands automatically, making the example more useful.