### PR TITLE
Update Incompatible Mods List

### DIFF
--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -101,7 +101,7 @@ MystCraft
 ~~~~~~~~~
 - Versions: All (so far)
 - Problem: Crash on startup
-- Solution: Update to Spongeforge 7.3.0 or newer.
+- Solution: Change ``B:useconfigs=false`` to ``true`` in the ``config/mystcraft/core.cfg`` file
 
 Open Terrain Generator (OTG)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -95,13 +95,13 @@ LagGoggles/TickCentral
 ~~~~~~~~~~~~~~~~~~~~~~
 - Versions: All
 - Problem: Crash on startup (mixin conflict).
-- Solution: No compatibility at present. Choose one or the other.
+- Solution: Update to Spongeforge 7.2.0 or newer.
 
 MystCraft
 ~~~~~~~~~
 - Versions: All (so far)
 - Problem: Crash on startup
-- Solution: No compatibility at present. Choose one or the other.
+- Solution: Update to Spongeforge 7.3.0 or newer.
 
 Open Terrain Generator (OTG)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The Mod Laggoggles/Tickcentral is Compatible with API 7.2.0 or newer and the Mod Mystcraft is Compatible when changing B:useconfigs=false to true in the config/mystcraft/core.cfg file so this PR updates the list to tell people how to fix.