### PR TITLE
Update jdlinker and try out new feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==3.2.1
 sphinx-intl==2.0.1
-sphinx-JDLinker==1.4
+sphinx-JDLinker==2.0.1
 sponge-docs-theme~=0.6.1

--- a/source/conf.py
+++ b/source/conf.py
@@ -90,7 +90,7 @@ gettext_compact = False
 # -- sphinx-JDLinker Configuration ----------------------------------------
 
 javadoc_links = {
-    'https://jd.spongepowered.org/%s/' % release: ['org.spongepowered.api'],
+    'https://jd.spongepowered.org/%s/' % release: ['org.spongepowered.api', 'sponge'],
     'https://configurate.aoeu.xyz/apidocs/': ['ninja.leaping.configurate'],
     'https://docs.oracle.com/javase/8/docs/api/': ['java'],
     'https://google.github.io/guava/releases/17.0/api/docs/': ['com.google.common']

--- a/source/plugin/assets.rst
+++ b/source/plugin/assets.rst
@@ -3,7 +3,7 @@ The Asset API
 =============
 
 .. javadoc-import::
-    org.spongepowered.api.asset.Asset
+    sponge:asset.Asset
     org.spongepowered.api.asset.AssetManager
     org.spongepowered.api.plugin.PluginContainer
 


### PR DESCRIPTION
The jdlinker has just undergone a massive rewrite (some bugs may be expected), but also a new feature has been added. A shorthand method to importing javadoc links. Instead of typing the full ``org.spongepowered.api``, you can simply type ``sponge:`` and the jdlinker will automatically convert that to the full package for you. Let me know what you think.