### PR TITLE
Fix ID name error

### DIFF
--- a/source/plugin/plugin-class.rst
+++ b/source/plugin/plugin-class.rst
@@ -37,7 +37,7 @@ usage is explained on :doc:`plugin-meta`.
 
     import org.spongepowered.plugin.Plugin;
 
-    @Plugin(id = "exampleplugin")
+    @Plugin("exampleplugin")
     public class ExamplePlugin {
 
     }
@@ -67,7 +67,7 @@ message as part of the server's initialization output.
     import com.google.inject.Inject;
     import org.apache.logging.log4j.Logger;
 
-    @Plugin(id = "exampleplugin")
+    @Plugin("exampleplugin")
     public class ExamplePlugin {
 
         @Inject


### PR DESCRIPTION
@Plugin(id = "exampleplugin") does not work according to my development. The working one is @Plugin("exampleplugin").

This PR fixes the issue, making the page more accurate