### PR TITLE
Fix documentation on ProvideServiceEvent

### DIFF
--- a/source/plugin/services.rst
+++ b/source/plugin/services.rst
@@ -44,11 +44,11 @@ construction code):
 .. code-block:: java
 
     import org.spongepowered.api.event.Listener
-    import org.spongepowered.api.service.ServiceProvider.ServerScoped
+    import org.spongepowered.api.event.lifecycle.ProvideServiceEvent
     import org.spongepowered.api.service.permission.PermissionService
 
     @Listener
-    public void providePermissionService(final ProvideServiceEvent.ServerScoped<PermissionService> event) {
+    public void providePermissionService(final ProvideServiceEvent.EngineScoped<PermissionService> event) {
         event.suggest(() -> new ConcretePermissionService());
     }
 


### PR DESCRIPTION
1. Use the correct import.
2. The event is called [ProvideServiceEvent.EngineScoped](https://jd.spongepowered.org/spongeapi/8.0.0/org/spongepowered/api/event/lifecycle/ProvideServiceEvent.EngineScoped.html).