### PR TITLE
Updated items

### DIFF
--- a/source/plugin/items/creating.rst
+++ b/source/plugin/items/creating.rst
@@ -2,14 +2,9 @@
 Creating an ItemStack
 =====================
 
-.. warning::
-    These docs were written for SpongeAPI 7 and are likely out of date. 
-    `If you feel like you can help update them, please submit a PR! <https://github.com/SpongePowered/SpongeDocs>`__
-
 .. javadoc-import::
     org.spongepowered.api.block.BlockState
-    org.spongepowered.api.data.key.Keys
-    org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData
+    org.spongepowered.api.data.Keys
     org.spongepowered.api.entity.Entity
     org.spongepowered.api.entity.EntityType
     org.spongepowered.api.entity.EntityTypes
@@ -38,9 +33,8 @@ and is unbreakable. If you want a plain sword without any other data, then this 
     }
 
 Creating the basic item is done. Now this is a normal diamond sword that we created, but what if we wanted something
-more interesting? What about enchanting and naming our sword? We can use :javadoc:`EnchantmentData` to give our sword
-some enchantments. The following example will give our sword every enchantment in the game, to level 1000. Make sure to
-include this all before ``return superMegaAwesomeSword;``.
+more interesting? What about enchanting and naming our sword? We can use :javadoc:`Keys#APPLIED_ENCHANTMENTS` to give 
+our sword some enchantments. The following example will give our sword every enchantment in the game, to level 1000.
 
 .. code-block:: java
 
@@ -48,20 +42,20 @@ include this all before ``return superMegaAwesomeSword;``.
     import java.util.stream.Collectors;
 
     import org.spongepowered.api.Sponge;
-    import org.spongepowered.api.data.manipulator.mutable.item.EnchantmentData;
     import org.spongepowered.api.data.meta.ItemEnchantment
     import org.spongepowered.api.item.Enchantment;
 
-    EnchantmentData enchantmentData = superMegaAwesomeSword
-        .getOrCreate(EnchantmentData.class).get();
-    final List<EnchantmentType> enchantments = Sponge.getRegistry()
-        .getAllOf(EnchantmentType.class).stream().collect(Collectors.toList());
+    public void withThousandEnchantmentLevel(ItemStack superMegaAwesomeSword){
+        List<Enchantment> enchantments = RegistryTypes
+            .ENCHANTMENT_TYPE
+            .get()
+            .stream()
+            .filter(type -> type.canBeAppliedToStack(superMegaAwesomeSword))
+            .map(type -> Enchantment.of(type, 1000))
+            .collect(Collectors.toList());
 
-    for (EnchantmentType enchantment : enchantments) {
-        enchantmentData.set(enchantmentData.enchantments()
-            .add(Enchantment.of(enchantment, 1000)));
+        superMegaAwesomeSword.offer(Keys.APPLIED_ENCHANTMENTS);
     }
-    superMegaAwesomeSword.offer(enchantmentData);
 
 Now let's say we wanted to give our overpowered sword a cool name to go with it. Here, we can directly offer a key to
 the ``ItemStack``. Using this key, we can change the name of the ``ItemStack`` to "SUPER MEGA AWESOME Diamond Sword"
@@ -71,14 +65,14 @@ the ``ItemStack``. Using this key, we can change the name of the ``ItemStack`` t
     import net.kyori.adventure.text.Component;
     import net.kyori.adventure.text.TextComponent;
     import net.kyori.adventure.text.format.NamedTextColor;
-    import org.spongepowered.api.data.key.Keys;
+    import org.spongepowered.api.data.Keys;
     import org.spongepowered.api.item.ItemTypes;
 
     superMegaAwesomeSword.offer(Keys.DISPLAY_NAME, TextComponent.ofChildren(
         Component.text("SUPER ", NamedTextColor.BLUE),
         Component.text("MEGA ", NamedTextColor.GOLD),
         Component.text("AWESOME ", NamedTextColor.DARK_AQUA),
-        ItemTypes.DIAMOND_SWORD.asComponent().color(NamedTextColor.AQUA));
+        ItemTypes.DIAMOND_SWORD.get().asComponent().color(NamedTextColor.AQUA));
 
 Finally, to make the sword unbreakable, we can use keys again:
 
@@ -105,13 +99,13 @@ An example is shown below:
     import org.spongepowered.api.event.CauseStackManager.StackFrame;
     import org.spongepowered.api.world.Location;
     import org.spongepowered.api.world.World;
-    import org.spongepowered.api.world.extent.Extent;
+    import org.spongepowered.api.world.server.ServerWorld;
 
     import java.util.Optional;
     
-    public void spawnItem(ItemStack superMegaAwesomeSword, Location<World> spawnLocation) {
-        Extent extent = spawnLocation.getExtent();
-        Entity item = extent.createEntity(EntityTypes.ITEM, spawnLocation.getPosition());
+    public void spawnItem(ItemStack superMegaAwesomeSword, ServerLocation spawnLocation) {
+        ServerWorld world = spawnLocation.world();
+        Item item = world.createEntity(EntityTypes.ITEM, spawnLocation.getPosition());
         item.offer(Keys.REPRESENTED_ITEM, superMegaAwesomeSword.createSnapshot());
 
         try (StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {

--- a/source/plugin/items/creating.rst
+++ b/source/plugin/items/creating.rst
@@ -108,9 +108,9 @@ An example is shown below:
         Item item = world.createEntity(EntityTypes.ITEM, spawnLocation.getPosition());
         item.offer(Keys.REPRESENTED_ITEM, superMegaAwesomeSword.createSnapshot());
 
-        try (StackFrame frame = Sponge.getCauseStackManager().pushCauseFrame()) {
+        try (StackFrame frame = Sponge.server().causeStackManager().pushCauseFrame()) {
             frame.addContext(EventContextKeys.SPAWN_TYPE, SpawnTypes.PLACEMENT);
-            extent.spawnEntity(item);
+            word.spawnEntity(item);
         }
     }
 

--- a/source/plugin/items/index.rst
+++ b/source/plugin/items/index.rst
@@ -2,10 +2,6 @@
 Items
 =====
 
-.. warning::
-    These docs were written for SpongeAPI 7 and are likely out of date. 
-    `If you feel like you can help update them, please submit a PR! <https://github.com/SpongePowered/SpongeDocs>`__
-
 Items are a fundamental feature of Minecraft and plugins. This section shows some basic usage examples and how to
 create your own items.
 

--- a/source/plugin/items/usage.rst
+++ b/source/plugin/items/usage.rst
@@ -2,10 +2,6 @@
 Basic Item Usage
 ================
 
-.. warning::
-    These docs were written for SpongeAPI 7 and are likely out of date. 
-    `If you feel like you can help update them, please submit a PR! <https://github.com/SpongePowered/SpongeDocs>`__
-
 .. javadoc-import::
     net.kyori.adventure.text.Component
     org.spongepowered.api.data.key.Keys
@@ -22,7 +18,7 @@ actual ``ItemStack`` and thus, you will need to set it back into an inventory if
 Checking an Item's Type
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Checking the type of the item is very simple. You just need to call the :javadoc:`ItemStack#getType()` method.
+Checking the type of the item is very simple. You just need to call the :javadoc:`ItemStack#type()` method.
 
 .. code-block:: java
 
@@ -31,13 +27,13 @@ Checking the type of the item is very simple. You just need to call the :javadoc
     import org.spongepowered.api.item.inventory.ItemStack;
 
     public boolean isStick(ItemStack stack) {
-        ItemType type = stack.getType();
-        return type.equals(ItemTypes.STICK);
+        ItemType type = stack.type();
+        return type.equals(ItemTypes.STICK.get());
     }
 
 See how simple that is? Because sticks can stack, we can also find out how many are present.
 
-Getting the number of items in an ``ItemStack`` is relatively easy. The :javadoc:`ItemStack#getQuantity()` method will
+Getting the number of items in an ``ItemStack`` is relatively easy. The :javadoc:`ItemStack#quantity()` method will
 handle this for us.
 
 Modifying ItemStack Data
@@ -86,29 +82,22 @@ Item Properties
 Certain items may hold specific properties. For example, certain items can mine specific blocks, such as a diamond
 pickaxe to obsidian. Properties are used for determining if an item can cause an action without actually checking up
 the type of the item. We can check if an item can mine obsidian by using the
-:javadoc:`HarvestingProperty` of that item.
+:javadoc:`Keys#CAN_HARVEST` of that item.
 
 .. code-block:: java
 
     import org.spongepowered.api.block.BlockTypes;
-    import org.spongepowered.api.data.property.item.HarvestingProperty;
-
-    import java.util.Optional;
 
     public boolean canMineObsidian(ItemStack stack) {
-        Optional<HarvestingProperty> optional =
-            stack.getProperty(HarvestingProperty.class);
-
-        if (optional.isPresent()) {
-            HarvestingProperty property = optional.get();
-            return property.getValue().contains(BlockTypes.OBSIDIAN);
-        }
-        return false;
+        List<BlockType> canHarvest =
+            stack.get(Keys.CAN_HARVEST).orElse(Collections.emptyList());
+        return canHarvest.contains(BlockTypes.OBSIDIAN.get());
     }
 
-This code will check to see if the item has a ``HarvestingProperty``, such as a pickaxe. If present, it will then
-return if this item can harvest obsidian without the need to check the type of the item. This is useful in the event
-that a mod or a Minecraft update adds a new tool with the capabilities of mining obsidian.
+This code will check to see if the item has a assigned key of ``CAN_HARVEST``, such as a pickaxe, 
+if it doesn't then it uses an empty array. It will then return if obsidian is contained within the list of blocks the 
+item can harvest. This is useful in the event that a mod or a Minecraft update adds a new tool with the capabilities of 
+mining obsidian.
 
 Comparing ItemStacks
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Updates the item docs to api 8

## Main Changes

To be fair, items havent changed too much in terms of text describing the api from 7 to 8, so there isn't much to talk about

### Item properties
While these have been removed in API 8 with it being changed to ``Keys``, I am wanting to change this to item type ``keys``. Just need to find a good example.

## On Hold

~~This is being blocked by https://github.com/SpongePowered/Sponge/issues/3845 (unless there is no keys to begin with for ItemType)~~ Fixed

Im wanting to double check the changes have applied. Need some free time

