### PR TITLE
Updated mods list

### DIFF
--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -32,13 +32,12 @@ Some mods may register there own permissions with Forge. These cannot be tracked
 bug that was fixed in December 2021 (after forge stopped updating 1.16.5) so permissions plugins will not be able to use
 these permissions.
 
-Applied Energistics 2
-~~~~~~~~~~~~~~~~~~~~~
+Abnormals_core
+~~~~~~~~~~~~~~
 
-- Versions: 8.4.7
-- Problem: Non-fatal console error when opening `Drive` gui
-- Solution: None so far
-- Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
+- Version: 3.3.1
+- Problem: Crash on startup
+- Solution: Use unoffical patched for Sponge version on the server. Download `Abnormals_core-1.16.5-3.3.1 <https://cdn.discordapp.com/attachments/406987481825804290/949798054117122058/abnormals_core-1.16.5-3.3.1.jar>`_
 
 AlexsMobs
 ~~~~~~~~~
@@ -48,13 +47,6 @@ AlexsMobs
 - Solution: None so far
 - Github issue: `Exception exiting Phase crash from AlexsMobs <https://github.com/SpongePowered/Sponge/issues/3535>`_
 
-Abnormals_core
-~~~~~~~~~~~~~~
-
-- Version: 3.3.1
-- Problem: Crash on startup
-- Solution: Use unoffical patched for Sponge version on the server. Download `Abnormals_core-1.16.5-3.3.1 <https://cdn.discordapp.com/attachments/406987481825804290/949798054117122058/abnormals_core-1.16.5-3.3.1.jar>`_
-
 All The Mods 6
 ~~~~~~~~~~~~~~
 
@@ -62,6 +54,14 @@ All The Mods 6
 - Problem: Crash on startup
 - Solution: Update SpongeForge to the latest
 - Github issue: `SpongeForge 1.16.5 InvalidMixinException ATM6 <https://github.com/SpongePowered/Sponge/issues/3647>`_
+
+Applied Energistics 2
+~~~~~~~~~~~~~~~~~~~~~
+
+- Versions: 8.4.7
+- Problem: Non-fatal console error when opening `Drive` gui
+- Solution: None so far
+- Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
 
 Bountiful Baubles
 ~~~~~~~~~~~~~~~~~
@@ -87,30 +87,6 @@ Create Mod
 - Solution: None so far
 - Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
 
-Random patches
-~~~~~~~~~~~~~~
-
-- Version: 2.4.4
-- Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
-- Github issue: `Server crash with Randompatches <https://github.com/SpongePowered/Sponge/issues/3589>`_
-
-Twilight Forest
-~~~~~~~~~~~~~~~
-
-- Version: 4.0.870
-- Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
-- Github issue: `SpongeForge has fatal errors with Twilight Forest mod <https://github.com/SpongePowered/Sponge/issues/3574>`_
-
-Progressive Bosses
-~~~~~~~~~~~~~~~~~~
-
-- Version 3.4.3
-- Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
-- Github issue: `Illegal State Exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
-
 Pehkui
 ~~~~~~
 
@@ -127,6 +103,22 @@ Physics Mod
 - Solution: None so far
 - Github issue: `Fatel server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
 
+Progressive Bosses
+~~~~~~~~~~~~~~~~~~
+
+- Version 3.4.3
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `Illegal State Exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
+
+Random patches
+~~~~~~~~~~~~~~
+
+- Version: 2.4.4
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `Server crash with Randompatches <https://github.com/SpongePowered/Sponge/issues/3589>`_
+
 Tickers' Construct
 ~~~~~~~~~~~~~~~~~~
 
@@ -134,6 +126,14 @@ Tickers' Construct
 - Problem: Non-fatal console error when opening an inventory
 - Solution: None so far
 - Github issue: `Tinkers' Construct slot transaction spam with SpongeForge <https://github.com/SpongePowered/Sponge/issues/3527>`_
+
+Twilight Forest
+~~~~~~~~~~~~~~~
+
+- Version: 4.0.870
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `SpongeForge has fatal errors with Twilight Forest mod <https://github.com/SpongePowered/Sponge/issues/3574>`_
 
 Valkyrien Skies
 ~~~~~~~~~~~~~~~

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -28,8 +28,8 @@ This makes it load the Sponge version of Mixin first, and can resolve many probl
 Forge Permissions
 ~~~~~~~~~~~~~~~~~
 
-Some mods may register there own permissions with Forge. These cannot be tracked by mods including SpongeForge due to a 
-bug that was fixed in December 2021 (after forge stopped updating 1.16.5) so permissions plugins will not be able to use
+Some mods may register their own permissions with Forge. These cannot be tracked by mods, including SpongeForge due to 
+a bug that was fixed in December 2021 (after forge stopped updating 1.16.5) so permissions plugins will not be able to use
 these permissions.
 
 Abnormals_core
@@ -37,14 +37,18 @@ Abnormals_core
 
 - Version: 3.3.1
 - Problem: Crash on startup
-- Solution: Use unoffical patched for Sponge version on the server. Download `Abnormals_core-1.16.5-3.3.1 <https://cdn.discordapp.com/attachments/406987481825804290/949798054117122058/abnormals_core-1.16.5-3.3.1.jar>`_
+- Solution: Use unoffical patched version on the server. Download `Abnormals_core-1.16.5-3.3.1 <https://cdn.discordapp.com/attachments/406987481825804290/949798054117122058/abnormals_core-1.16.5-3.3.1.jar>`_
 
-AlexsMobs
-~~~~~~~~~
+Alex's Mobs
+~~~~~~~~~~~
 
 - Version: 1.10.1
 - Problem: Crashes randomly
-- Solution: None so far
+- Solution: Update mods to at least
+    - SpongeForge: RC1313
+    - Forge: 1.16.5-36.2.39
+    - Alex's Mobs: 1.12.1
+    - Citadel: 1.8.1
 - Github issue: `Exception exiting Phase crash from AlexsMobs <https://github.com/SpongePowered/Sponge/issues/3535>`_
 
 All The Mods 6
@@ -52,7 +56,7 @@ All The Mods 6
 
 - Version: 1.8.28
 - Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
+- Solution: Update SpongeForge to RC1313
 - Github issue: `SpongeForge 1.16.5 InvalidMixinException ATM6 <https://github.com/SpongePowered/Sponge/issues/3647>`_
 
 Applied Energistics 2
@@ -77,7 +81,7 @@ Conquest Reforged
 - Version: 5.0.7
 - Problem: Breaking a block with a snow layer in hand causes crash
 - Solution: None so far
-- Github issue: `Server crashes when creaking a block with snow layer in your hand <https://github.com/SpongePowered/Sponge/issues/3621>`_
+- Github issue: `Server crashes when breaking a block with snow layer in your hand <https://github.com/SpongePowered/Sponge/issues/3621>`_
 
 Create Mod
 ~~~~~~~~~~
@@ -100,7 +104,7 @@ Physics Mod
 
 - Version: 1.3.4
 - Problem: Lag on TNT use 
-- Solution: None so far
+- Solution: Update SpongeForge to RC1313+ and Physics Mod to 2.6.7 
 - Github issue: `Fatel server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
 
 Progressive Bosses
@@ -108,8 +112,8 @@ Progressive Bosses
 
 - Version 3.4.3
 - Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
-- Github issue: `Illegal State Exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
+- Solution: Update SpongeForge to RC1313+
+- Github issue: `Illegal state exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
 
 Random patches
 ~~~~~~~~~~~~~~
@@ -119,7 +123,7 @@ Random patches
 - Solution: Update SpongeForge to the latest
 - Github issue: `Server crash with Randompatches <https://github.com/SpongePowered/Sponge/issues/3589>`_
 
-Tickers' Construct
+Tinkers' Construct
 ~~~~~~~~~~~~~~~~~~
 
 - Version: 1.16.5-3.1.2.265
@@ -149,4 +153,6 @@ World Edit
 - Version: 7.2.5
 - Problem: Fatal errors after startup relating to commands
 - Solution: None so far
-- Github issue: `WorldEdit command registrar issue on server start <https://github.com/SpongePowered/Sponge/issues/3540>`_
+- Github issue: 
+    - `WorldEdit command registrar issue on server start <https://github.com/SpongePowered/Sponge/issues/3540>`_
+    - `WorldEdit mod malfunctions with SpongeForge present <https://github.com/SpongePowered/Sponge/issues/3811>`_

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -14,109 +14,139 @@ To help you resolve which is which, and how to fix the problem (if possible), we
 can cause problems when used alongside SpongeForge. Please note that, whilst we will try to keep it current, changes may
 happen as mods are updated. You can help by letting us know when relevant changes happen, on Discord or GitHub.
 
-Known Incompatibilities (SpongeAPI 7)
-=====================================
+Known Incompatibilities
+=======================
 
 Old Mixins
 ~~~~~~~~~~
 
 First, a general note: If there is a warning about "old mixins" in the server log, the first step you should attempt is
 to rename the SpongeForge file, to make it first in the mod loading order. This can usually be done by prefixing the
-SpongeForge jar file name with ``aaa_``, giving a filename like ``aaa_spongeforge-1.12.2-2838-7.2.1-RC4011``. This makes it
-load the Sponge version of Mixin first, and can resolve many problems in one step.
+SpongeForge jar file name with ``aaa_``, giving a filename like ``aaa_spongeforge-1.16.5-36.2.5-8.1.0-RC1312``. 
+This makes it load the Sponge version of Mixin first, and can resolve many problems in one step.
 
-FarSeek
-~~~~~~~
-- Dependents: Streams mod
-- Versions: 2.3, 2.4
-- Problem: Crash on startup / Failed world generation
-- Solution: Update to version 2.5.
+Forge Permissions
+~~~~~~~~~~~~~~~~~
 
-FoamFix
-~~~~~~~
-- Versions: Up to 0.10.7
-- Problem: Crash on startup (block collision error)
-- Solution: Update to version 0.10.8 or newer, or change these two configuration options:
-  ``optimizedBlockPos=false`` and ``patchChunkSerialization=false``
-- *Newer versions of FoamFix (0.10.8+) automatically correct this when SpongeForge is present.*
+Some mods may register there own permissions with Forge. These cannot be tracked by mods including SpongeForge due to a 
+bug that was fixed in December 2021 (after forge stopped updating 1.16.5) so permissions plugins will not be able to use
+these permissions.
 
-ForgeEssentials
-~~~~~~~~~~~~~~~
-- Versions: Up to 12.3.82
-- Problem: Crash on startup (mixin NoSuchMethodError)
-- Solution: Update to 12.3.83 or newer.
-- *Newer versions of ForgeEssentials have updated their Mixin usage to version 0.8.*
+Applied Energistics 2
+~~~~~~~~~~~~~~~~~~~~~
 
-Hammer Core
-~~~~~~~~~~~
-- Dependents: Many
-- Versions: 2.0.6.1.2+
-- Problem: Crash on startup. Typically, the following error message is returned:
+- Versions: 8.4.7
+- Problem: Error when opening `Drive` gui
+- Solution: None so far
+- Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
 
-.. code-block:: none
-
-    org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Redirector onUpdateTileEntities(Lnet/minecraft/util/ITickable;)V in mixins.common.core.json:world.WorldMixin failed injection check, (0/1) succeeded. Scanned 1 target(s). Using refmap mixins.common.refmap.json
-
-- Solution: Change ``<entry key="World.ITickable.Override">true</entry>`` to ``false`` in the ``/asm/hammercore.xml`` file
-
-ICBM Classic
-~~~~~~~~~~~~
-- Versions: All
-- Problem: Missiles stop in midair and appear to lag in place.
-- Solution: Add the commented text below to the ``entity-activation-range/mods`` section of the ``sponge/global.conf`` file:
-
-.. code-block:: none
-
-    entity-activation-range {
-        mods {
-            # COPY THIS - START
-            icbmclassic {
-                defaults {
-                    misc=16
-                }
-                # If 'false', entity activation rules for this mod will be ignored and always tick.
-                enabled=false
-                entities {
-                    missile=16
-                    seat=16
-                }
-            }
-            # COPY THIS - END
-        }
-    }
-
-Just Enough IDs (JEID)
-~~~~~~~~~~~~~~~~~~~~~~
-- Versions: Up to 1.0.3-48
-- Problem: Crash on startup (mixin conflict).
-- Solution: Update to version 1.0.3-54 or newer.
-
-LagGoggles/TickCentral
-~~~~~~~~~~~~~~~~~~~~~~
-- Versions: All
-- Problem: Crash on startup (mixin conflict).
-- Solution: Update to Spongeforge 7.2.0 or newer.
-
-MystCraft
+AlexsMobs
 ~~~~~~~~~
-- Versions: All (so far)
+
+- Version: 1.10.1
+- Problem: Crashes randomly
+- Solution: None so far
+- Github issue: `Exception exiting Phase crash from AlexsMobs <https://github.com/SpongePowered/Sponge/issues/3535>`_
+
+Abnormals_core
+~~~~~~~~~~~~~~
+
+- Version: 3.3.1
 - Problem: Crash on startup
-- Solution: Change ``B:useconfigs=false`` to ``true`` in the ``config/mystcraft/core.cfg`` file
+- Solution: Use unoffical patched for Sponge version on the server. Download `Abnormals_core-1.16.5-3.3.1 <https://cdn.discordapp.com/attachments/406987481825804290/949798054117122058/abnormals_core-1.16.5-3.3.1.jar>`_
 
-Open Terrain Generator (OTG)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- Dependencies: OTGcore
-- Versions: All (so far)
-- Problem: Crash on startup / Multiworld Wgen problems
-- Solution: Pre-generate world without SpongeForge, then remove OTG and add SpongeForge.
+All The Mods 6
+~~~~~~~~~~~~~~
 
-Phosphor
-~~~~~~~~
-- Versions: Up to 0.2.4
-- Problem (1): Crash on startup
-- Solution: Update to version 0.2.5 or newer, which is compatible with Sponge RC3844.
-- Problem (2): Poor graphic performance
-- Solution: Set the optimisation ``async-lighting`` to ``false`` in the Sponge ``global.conf`` file.
+- Version: 1.8.28
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `SpongeForge 1.16.5 InvalidMixinException ATM6 <https://github.com/SpongePowered/Sponge/issues/3647>`_
 
-There may be many more, please help us keep this list maintained by contributing to the SpongeDocs on GitHub!
-The :doc:`debugging` page may also be of help if your issue is not one of those mentioned above.
+Bountiful Baubles
+~~~~~~~~~~~~~~~~~
+
+- Version: 1.16.5-0.1.0-forge
+- Problem: Crash on startup
+- Solution: None so far
+- Github issue: `Bountiful Baubles blows up SF 1.16.5 <https://github.com/SpongePowered/Sponge/issues/3646>`_
+
+Conquest Reforged
+~~~~~~~~~~~~~~~~~
+
+- Version: 5.0.7
+- Problem: Breaking a block with a snow layer in hand causes crash
+- Solution: None so far
+- Github issue: `Server crashes when creaking a block with snow layer in your hand <https://github.com/SpongePowered/Sponge/issues/3621>`_
+
+Create Mod
+~~~~~~~~~~
+
+- Version: mc1.16.5_v0.3.2g
+- Problem: Error when opening an inventory
+- Solution: None so far
+- Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
+
+Random patches
+~~~~~~~~~~~~~~
+
+- Version: 2.4.4
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `Server crash with Randompatches <https://github.com/SpongePowered/Sponge/issues/3589>`_
+
+Twilight Forest
+~~~~~~~~~~~~~~~
+
+- Version: 4.0.870
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `SpongeForge has fatal errors with Twilight Forest mod <https://github.com/SpongePowered/Sponge/issues/3574>`_
+
+Progressive Bosses
+~~~~~~~~~~~~~~~~~~
+
+- Version 3.4.3
+- Problem: Crash on startup
+- Solution: Update SpongeForge to the latest
+- Github issue: `Illegal State Exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
+
+Pehkui
+~~~~~~
+
+- Version: 3.4.2
+- Problem: Crash on startup
+- Solution: None so far
+- Github issue: `SpongeForge incompatibility with pehkui <https://github.com/SpongePowered/Sponge/issues/3829>`_
+
+Physics Mod
+~~~~~~~~~~~
+
+- Version: 1.3.4
+- Problem: Lag on TNT use 
+- Solution: None so far
+- Github issue: `Fatel server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
+
+Tickers Construct
+~~~~~~~~~~~~~~~~~
+
+- Version: 1.16.5-3.1.2.265
+- Problem: Error when opening an inventory
+- Solution: None so far
+- Github issue: `Tinkers Construct slot transaction spam with SpongeForge <https://github.com/SpongePowered/Sponge/issues/3527>`_
+
+Valkyrien Skies
+~~~~~~~~~~~~~~~
+
+- Version: 116-2.0.0-alpha6
+- Problem: Crash on startup
+- Solution: None so far
+- Github issue: `The server can't launch with Valkyrien Skies <https://github.com/SpongePowered/Sponge/issues/3809>`_
+
+World Edit
+~~~~~~~~~~
+
+- Version: 7.2.5
+- Problem: Errors after startup relating to commands
+- Solution: None so far
+- Github issue: `WorldEdit command registrar issue on server start <https://github.com/SpongePowered/Sponge/issues/3540>`_

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -36,7 +36,7 @@ Applied Energistics 2
 ~~~~~~~~~~~~~~~~~~~~~
 
 - Versions: 8.4.7
-- Problem: Error when opening `Drive` gui
+- Problem: Non-fatal console error when opening `Drive` gui
 - Solution: None so far
 - Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
 
@@ -83,7 +83,7 @@ Create Mod
 ~~~~~~~~~~
 
 - Version: mc1.16.5_v0.3.2g
-- Problem: Error when opening an inventory
+- Problem: Non-fatal console error when opening an inventory
 - Solution: None so far
 - Github issue: `Logged slot transactions without event <https://github.com/SpongePowered/Sponge/issues/3680>`_
 
@@ -127,13 +127,13 @@ Physics Mod
 - Solution: None so far
 - Github issue: `Fatel server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
 
-Tickers Construct
-~~~~~~~~~~~~~~~~~
+Tickers' Construct
+~~~~~~~~~~~~~~~~~~
 
 - Version: 1.16.5-3.1.2.265
-- Problem: Error when opening an inventory
+- Problem: Non-fatal console error when opening an inventory
 - Solution: None so far
-- Github issue: `Tinkers Construct slot transaction spam with SpongeForge <https://github.com/SpongePowered/Sponge/issues/3527>`_
+- Github issue: `Tinkers' Construct slot transaction spam with SpongeForge <https://github.com/SpongePowered/Sponge/issues/3527>`_
 
 Valkyrien Skies
 ~~~~~~~~~~~~~~~
@@ -147,6 +147,6 @@ World Edit
 ~~~~~~~~~~
 
 - Version: 7.2.5
-- Problem: Errors after startup relating to commands
+- Problem: Fatal errors after startup relating to commands
 - Solution: None so far
 - Github issue: `WorldEdit command registrar issue on server start <https://github.com/SpongePowered/Sponge/issues/3540>`_

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -105,7 +105,7 @@ Physics Mod
 - Version: 1.3.4
 - Problem: Fatal: Lag on TNT use 
 - Solution: Update SpongeForge to RC1313+ and Physics Mod to 2.6.7 
-- Github issue: `Fatel server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
+- Github issue: `Fatal server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
 
 Progressive Bosses
 ~~~~~~~~~~~~~~~~~~

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -120,7 +120,7 @@ Random patches
 
 - Version: 2.4.4
 - Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
+- Solution: Update SpongeForge to the RC1313+
 - Github issue: `Server crash with Randompatches <https://github.com/SpongePowered/Sponge/issues/3589>`_
 
 Tinkers' Construct
@@ -136,7 +136,7 @@ Twilight Forest
 
 - Version: 4.0.870
 - Problem: Crash on startup
-- Solution: Update SpongeForge to the latest
+- Solution: Update SpongeForge to the RC1313+
 - Github issue: `SpongeForge has fatal errors with Twilight Forest mod <https://github.com/SpongePowered/Sponge/issues/3574>`_
 
 Valkyrien Skies

--- a/source/server/spongineer/incompatible.rst
+++ b/source/server/spongineer/incompatible.rst
@@ -103,7 +103,7 @@ Physics Mod
 ~~~~~~~~~~~
 
 - Version: 1.3.4
-- Problem: Lag on TNT use 
+- Problem: Fatal: Lag on TNT use 
 - Solution: Update SpongeForge to RC1313+ and Physics Mod to 2.6.7 
 - Github issue: `Fatel server lag when using TNT and Physics mod <https://github.com/SpongePowered/Sponge/issues/3517>`_
 
@@ -113,9 +113,9 @@ Progressive Bosses
 - Version 3.4.3
 - Problem: Crash on startup
 - Solution: Update SpongeForge to RC1313+
-- Github issue: `Illegal state exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
+- Github issue: `Illegal State Exception with Progressive Bosses mod <https://github.com/SpongePowered/Sponge/issues/3714>`_
 
-Random patches
+Random Patches
 ~~~~~~~~~~~~~~
 
 - Version: 2.4.4


### PR DESCRIPTION
Updates the mods list to api 8

## Main Changes

When it comes to 1.16.5 mod issues, i found a lot more then 1.12.2 on Github, most without solutions. Not sure if the stance on this sort of thing was to ignore the ones without a solution or that the docs weren't updated for a while or there was generally not too many 1.12.2 issues. Eitherway I have included the ones without any issues as I believe that sort of information should be out there stating `I am aware of the issue`. 

For this reason I have also included a github issue tag for all issues (except abnormal core .... as I couldnt find one -> took the discord pinned as the issue) so if there is a update to any of the incompatibilities then users can click on the github issue and see the update before the docs are updated.

![Screen Shot 2023-04-21 at 13 55 56-fullpage](https://user-images.githubusercontent.com/3740689/233641536-aaa8f161-0b84-4475-85c5-e54393fed90e.png)

