### PR TITLE
[API 8] Removes API7 warning 

### DIFF
--- a/source/plugin/blocks/modifying.rst
+++ b/source/plugin/blocks/modifying.rst
@@ -2,10 +2,6 @@
 Modifying Blocks
 ================
 
-.. warning::
-    These docs were written for SpongeAPI 7 and are likely out of date. 
-    `If you feel like you can help update them, please submit a PR! <https://github.com/SpongePowered/SpongeDocs>`__
-
 .. javadoc-import::
     org.spongepowered.api.block.BlockSnapshot
     org.spongepowered.api.block.BlockState


### PR DESCRIPTION
One API 7 warning slipped by the approval. This remove the one that slipped by