### PR TITLE
Api versions update

### DIFF
--- a/source/plugin/api-versions.rst
+++ b/source/plugin/api-versions.rst
@@ -13,7 +13,7 @@ This page explains which API versions exist, and to which Minecraft version thei
 | *10.0.0*    | TBA          | TBA            | * SpongeForge (1.19.4 - expected)         |
 |             |              |                | * SpongeVanilla (1.19.4)                  |
 +-------------+--------------+----------------+-------------------------------------------+
-| *9.0.0*     | May 19 2022  | April 1, 2023  | * SpongeVanilla (1.18.2)                  |
+| 9.0.0       | May 19 2022  | April 1, 2023  | * SpongeVanilla (1.18.2)                  |
 +-------------+--------------+----------------+-------------------------------------------+
 | 8.0.0       | Jan 8, 2022  | TBA            | * SpongeForge (1.16.5)                    |
 |             |              |                | * SpongeVanilla (1.16.5)                  |

--- a/source/plugin/api-versions.rst
+++ b/source/plugin/api-versions.rst
@@ -7,8 +7,13 @@ This page explains which API versions exist, and to which Minecraft version thei
 +-------------+--------------+----------------+-------------------------------------------+
 | API-Version | Release Date | End of Support | Known Implementations (Minecraft Version) |
 +=============+==============+================+===========================================+
-| *9.0.0*     | TBA          | TBA            | * SpongeForge (1.18.1 - expected)         |
-|             |              |                | * SpongeVanilla (1.18.1 - expected)       |
+| *11.0.0*    | TBA          | TBA            | * SpongeForge (1.20.1 - expected)         |
+|             |              |                | * SpongeVanilla (1.20.1 - expected)       |
++-------------+--------------+----------------+-------------------------------------------+
+| *10.0.0*    | TBA          | TBA            | * SpongeForge (1.19.4 - expected)         |
+|             |              |                | * SpongeVanilla (1.19.4)                  |
++-------------+--------------+----------------+-------------------------------------------+
+| *9.0.0*     | May 19 2022  | April 1, 2023  | * SpongeVanilla (1.18.2)                  |
 +-------------+--------------+----------------+-------------------------------------------+
 | 8.0.0       | Jan 8, 2022  | TBA            | * SpongeForge (1.16.5)                    |
 |             |              |                | * SpongeVanilla (1.16.5)                  |


### PR DESCRIPTION
Clicked in this page and found it still said API 9 hadnt been released and that it had a sponge forge planned and also no mention of API10+ 