### PR TITLE
(API 8) Minor updates

### DIFF
--- a/source/plugin/commands/commandbuilding.rst
+++ b/source/plugin/commands/commandbuilding.rst
@@ -12,6 +12,7 @@ Building a Command
     org.spongepowered.api.command.exception.ArgumentParseException
     org.spongepowered.api.event.lifecycle.RegisterCommandEvent
     org.spongepowered.api.event.EventContextKeys
+    org.spongepowered.api.world.Locatable
     org.spongepowered.plugin.PluginContainer
     net.kyori.adventure.text.Component
     
@@ -83,7 +84,7 @@ a target player on the command cause.
             .executor(new HelloWorldCommand())
             .permission("myplugin.command.helloWorld")
             .shortDescription(Component.text("Hello World Command"))
-            .executionRequirements(context -> context.cause().context().get(EventContextKeys.PLAYER).isPresent())
+            .executionRequirements(context -> context.cause().root() instanceof ServerPlayer)
             .build();
     }
 
@@ -98,7 +99,7 @@ a target player on the command cause.
 .. tip::
 
     Often times command are put in as player-only as they require the location in the world the command was
-    executed from. Best practise would be to check for the target location using :javadoc:`EventContextKeys#LOCATION`
+    executed from. Best practise would be to check if the root of the command is :javadoc:`Locatable`
     instead of the player as this would allow command blocks to run the command without specifying a player.
 
 Writing a Command Executor
@@ -186,6 +187,11 @@ Registering a Command
 Commands are registered on a :javadoc:`RegisterCommandEvent`. The event takes a generic which is the type of command 
 that is being registered to it. To register a command, the 
 :javadoc:`RegisterCommandEvent#register(PluginContainer, C, String, String...)` method needs to be invoked.
+
+In the following example, we register two commands. ``helloworld`` which is from the building a simple command example 
+above, as well as a raw command which is explained in :doc:`rawcommand`. These two commands need to be registered in different listeners
+as they are different command types, however in most cases a single listener will suffice as all commands in a single plugin
+are typically of the same type.
 
 .. code-block:: java
 

--- a/source/plugin/commands/commandmanager.rst
+++ b/source/plugin/commands/commandmanager.rst
@@ -63,4 +63,4 @@ Sending a Command As a Player With Console Permissions
 
     Sponge.server().causeStackManager().pushCause(player);
     CommandManager cmdManager = Sponge.server().commandManager();
-    cmdManager.process(console, player, "kill Nitch");
+    cmdManager.process(console, player, "kill Notch");

--- a/source/plugin/commands/commandmanager.rst
+++ b/source/plugin/commands/commandmanager.rst
@@ -11,20 +11,56 @@ The :javadoc:`CommandManager` stands as the manager for watching what commands g
 to the right command handler. To register your commands, use the :javadoc:`RegisterCommandEvent` as shown on 
 :doc:`./commandbuilding`.
 
-The ``CommandManager`` can also be used to call a command programmatically.
+Command Execution
+~~~~~~~~~~~~~~~~~
+
+When executing a command Sponge splits the sender into three categories.
+
+The first category is the ``permissions subject`` which is the target to
+check permissions for. The second cateogory is the ``audience`` which is 
+the target for all messages to be sent to. With the last category being 
+the actual ``sender`` who is the object that sent the command.
+
+.. warning::
+
+    When executing a command programticly, you need to specifiy the permissions
+    subject and the audience but not the sender as by default the sender will be
+    the permissions manager. 
+
+    The command sender can be changed by pushing the new sender to the root of the
+    cause stack.
+
+
+Sending a Command As a Player
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: java
 
+    ServerPlayer player;
+
+    Sponge.server().causeStackManager().pushCause(player);
+    CommandManager cmdManager = Sponge.server().commandManager();
     cmdManager.process(player, "msg Notch hi notch!");
 
-You can also send a command from the server console
+Sending a command as a console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: java
 
-    cmdManager.process(Sponge.systemSubject(), "kill Notch");
+    SystemSubject console = Sponge.systemSubject();
 
-You can also send a command as a player, but with server console permissions.
+    Sponge.server().causeStackManager().pushCause(console);
+    CommandManager cmdManager = Sponge.server().commandManager();
+    cmdManager.process(console, "kill Notch");
+
+Sending a Command As a Player With Console Permissions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: java
 
-    cmdManager.process(Sponge.systemSubject(), player, "kill Nitch");
+    ServerPlayer player;
+    SystemSubject console = Sponge.systemSubject();
+
+    Sponge.server().causeStackManager().pushCause(player);
+    CommandManager cmdManager = Sponge.server().commandManager();
+    cmdManager.process(console, player, "kill Nitch");

--- a/source/plugin/commands/commandmanager.rst
+++ b/source/plugin/commands/commandmanager.rst
@@ -42,7 +42,7 @@ Sending a Command As a Player
     CommandManager cmdManager = Sponge.server().commandManager();
     cmdManager.process(player, "msg Notch hi notch!");
 
-Sending a command as a console
+Sending a Command As a Console
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: java

--- a/source/plugin/economy/implementing.rst
+++ b/source/plugin/economy/implementing.rst
@@ -3,6 +3,7 @@ Implementing the Economy API
 ============================
 
 .. javadoc-import::
+    org.spongepowered.api.event.economy.EconomyTransactionEvent
     org.spongepowered.api.service.economy.Currency
     org.spongepowered.api.service.economy.EconomyService
     org.spongepowered.api.service.economy.account.UniqueAccount
@@ -19,6 +20,21 @@ API, you must implement six classes:
 * :javadoc:`TransferResult`
 * :javadoc:`UniqueAccount`
 * :javadoc:`VirtualAccount`
+* :javadoc:`EconomyTransactionEvent`
+
+Registering Your Economy Service
+================================
+
+When it comes to registering any service in Sponge, you can provide your service as an option with Sponge deciding 
+which service to use if requested. This means that if two Economy Service plugins are used on a server, only one
+of the services will be used. 
+
+.. code-block:: java
+
+    @Listener
+    public void registerEconomyService(ProvideServiceEvent.EngineScoped<MyCustomEconomyService> event){
+        event.suggest(() -> new MyCustomEconomyService());
+    }
 
 Things to consider when implementing the Economy API
 ====================================================


### PR DESCRIPTION
This branch was meant for the economy, however this seems to be mostly updated anyway. So this branch became minor edits to the docs to provide more information. 

The following was added:

- A note to implement the ``EconomyTransactionEvent`` (Some Economy plugins don't fire this event -> could be a assumption that Sponge was going to do it for them which would be incorrect)
- Registering your Economy Service (In API8 its now done by events)
- Fixed player only command example
- Minor edit to specify that in a command register example, the two commands are different types and that the first command is referencing an example code block from the same page
- Clarified how to properly run a command via a player
- Clarified in a code block how to get the command manager 