### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/source/plugin/blocks/concepts.rst
+++ b/source/plugin/blocks/concepts.rst
@@ -43,7 +43,7 @@ With block properties having a known preset of possible values, these cannot be 
 whereby there is a infinite amount of possibilities. Examples include sign text and block inventories. 
 
 Minecraft's solution to this is block entities, which are Java objects that store additional data on a `Location`
-the block is at in `NBT format <https://minecraft.gamepedia.com/NBT_format>`_. Examples of block entities are 
+the block is at in `NBT format <https://minecraft.wiki/w/NBT_format>`_. Examples of block entities are 
 :javadoc:`Chest`
 
 Example use would be to receive the inventory of a chest. This can be done as follows

--- a/source/plugin/text/text.rst
+++ b/source/plugin/text/text.rst
@@ -141,7 +141,7 @@ useful when creating minigame plugins, but have a broad range of applications.
 
 .. tip::
 
-    Read this `Minecraft wiki article <https://minecraft.gamepedia.com/Commands#Target_selectors>`__ for help understanding
+    Read this `Minecraft wiki article <https://minecraft.wiki/w/Target_selectors>`__ for help understanding
     what target selectors are in Minecraft, and how to use them.
 
 To use selectors in text, there is a component factory for Selectors. This is illustrated in the example

--- a/source/server/getting-started/configuration/index.rst
+++ b/source/server/getting-started/configuration/index.rst
@@ -13,7 +13,7 @@ Configuring Sponge
 
 This article is about configuring Sponge itself; plugins will usually create their own configuration files inside the 
 server "config" directory.
-For Vanilla configuration check out the `Minecraft Wiki <https://minecraft.gamepedia.com/Server.properties>`__.
+For Vanilla configuration check out the `Minecraft Wiki <https://minecraft.wiki/w/Server.properties>`__.
 
 Sponge Configuration Files
 ==========================

--- a/source/server/getting-started/migrating.rst
+++ b/source/server/getting-started/migrating.rst
@@ -49,7 +49,7 @@ This is how it works:
    the ``root`` folder of the server (which is CraftBukkit standard).
 
 #. Now the migration is performed. At this point, worlds are copied over from what we call the ``world container`` into
-   the folder defined in the `server.properties <https://minecraft.gamepedia.com/Server.properties>`__ file via the
+   the folder defined in the `server.properties <https://minecraft.wiki/w/Server.properties>`__ file via the
    ``level-name`` key. Note that the original files in the ``world container`` remain unchanged, a *copy* is made during migration.
 
 #. Bukkit puts things in weird places (with weird names), thus two important fixes have to be applied. Keep in mind that

--- a/source/server/getting-started/port-forward.rst
+++ b/source/server/getting-started/port-forward.rst
@@ -15,7 +15,7 @@ IP address of your computer. UDP and TCP are the protocols that must be forwarde
 .. tip::
 
     You may change which port is used by editing the appropriate key in your
-    `server.properties <https://minecraft.gamepedia.com/Server.properties>`__.
+    `server.properties <https://minecraft.wiki/w/Server.properties>`__.
 
 Port Forwarding can be performed through your router's administrator panel. If you do not know how to navigate to your
 router's administration panel, conduct an internet search for specific instructions on port forwarding for your router.

--- a/source/server/management/bans.rst
+++ b/source/server/management/bans.rst
@@ -16,4 +16,4 @@ list of banned IP addresses is available using the command ``/banlist ips``
 A ban can be reversed using the command ``/pardon <name>`` or ``/pardon <ip-address>``
 
 
-More information on Bans can be found at the `Minecraft Wiki <https://minecraft.gamepedia.com/Commands/ban>`_.
+More information on Bans can be found at the `Minecraft Wiki <https://minecraft.wiki/w/Commands/ban>`_.

--- a/source/server/management/permissions.rst
+++ b/source/server/management/permissions.rst
@@ -10,13 +10,13 @@ Operator Level
 ==============
 
 Minecraft comes with a simple way to give permissions: by setting users as operator (or "op" for short). General
-information on op status can be found at https://minecraft.gamepedia.com/Op
+information on op status can be found at https://minecraft.wiki/w/Server#Managing_and_maintaining_a_server
 
 The abilities of op permission may be adjusted by altering the ``op-permission-level`` setting in the
-`server.properties <https://minecraft.gamepedia.com/Server.properties>`__ file.
+`server.properties <https://minecraft.wiki/w/Server.properties>`__ file.
 
 A list of native Minecraft server commands available to players with op can be found at the `Minecraft Wiki
-<https://minecraft.gamepedia.com/Commands#Summary_of_commands>`_.
+<https://minecraft.wiki/w/Commands#List_and_summary_of_commands>`_.
 
 
 .. warning::

--- a/source/server/management/whitelist.rst
+++ b/source/server/management/whitelist.rst
@@ -17,7 +17,7 @@ Players can be added to the whitelist through the usage of in-game :doc:`../spon
 - To reload the whitelist after a manual change to the file, use ``/whitelist reload``
 
 The whitelist can also be enabled or disabled by editing the
-`server.properties <https://minecraft.gamepedia.com/Server.properties>`__ file,
+`server.properties <https://minecraft.wiki/w/Server.properties>`__ file,
 although this will only affect the game after server reload or restart.
 
 Permissions

--- a/source/server/spongineer/commands.rst
+++ b/source/server/spongineer/commands.rst
@@ -82,7 +82,7 @@ Command                  Description                                Permission
 **Command Conflicts**
 
 In cases of command conflict, Sponge provides a primary alias mechanism to specify which command is to be used.  For
-example, Minecraft provides the `reload <https://minecraft.gamepedia.com/Commands#Summary_of_commands>`__ command and
+example, Minecraft provides the `reload <https://minecraft.wiki/w/Commands#List_and_summary_of_commands>`__ command and
 Sponge provides the `reload <https://docs.spongepowered.org/stable/en/server/spongineer/commands.html>`__ command. To
 specify which command to use, prefix it with ``minecraft`` or ``sponge`` and a ``:``. So, to use Sponge's reload command
 above, type in ``/sponge:reload``. This approach can also be used to handle conflicts between mods and/or plugins. Do
@@ -221,7 +221,7 @@ Command               Description                               Permission
 
 |
 
-A full list of vanilla commands can be found at: https://minecraft.gamepedia.com/Commands#List_of_commands. Permissions
+A full list of vanilla commands can be found at: https://minecraft.wiki/w/Commands#List_and_summary_of_commands. Permissions
 for vanilla Minecraft commands on a Sponge server are of the structure ``minecraft.command.<command>``.
 
 Command Features


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly (also fixes certain link headers).