### PR TITLE
Fixed links for adventure javadocs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -100,7 +100,11 @@ javadoc_links = {
     "https://jd.spongepowered.org/plugin-spi/0.3.0/": ["org.spongepowered.plugin"],
     "https://docs.oracle.com/javase/8/docs/api/": ["java"],
     "https://guava.dev/releases/21.0/api/docs/": ["com.google.common"],
-    "https://jd.adventure.kyori.net/api/4.9.3/": ["net.kyori.adventure"],
+    "https://jd.advntr.dev/serializer-configurate4/4.9.3/": ["net.kyori.adventure.serializer.configurate4"],
+    "https://jd.advntr.dev/text-serializer-plain/4.9.3/":["net.kyori.adventure.text.serializer.plain"],
+    "https://jd.advntr.dev/text-serializer-legacy/4.9.3/":["net.kyori.adventure.text.serializer.legacy"],
+    "https://jd.advntr.dev/text-serializer-gson/4.9.3/":["net.kyori.adventure.text.serializer.gson"],
+    "https://jd.advntr.dev/api/4.9.3/": ["net.kyori.adventure"],
 }
 
 # -- sphinx-intersphinx Configuration -------------------------------------

--- a/source/plugin/text/representations/index.rst
+++ b/source/plugin/text/representations/index.rst
@@ -7,7 +7,7 @@ Text Serializers
     net.kyori.adventure.text.serializer.ComponentSerializer
     net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
     net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
-    net.kyori.adventure.text.serializer.plain.PlainComponentSerializer
+    net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
     net.kyori.adventure.serializer.configurate4.ConfigurateComponentSerializer
     java.lang.String
 
@@ -18,7 +18,7 @@ Text Serializers
 :javadoc:`ComponentSerializer`\ s provide a convenient way to serialize and de-serialize :javadoc:`Component` instances.
 There are four applicable formats:
 
-* Unformatted string - :javadoc:`PlainComponentSerializer`
+* Unformatted string - :javadoc:`PlainTextComponentSerializer`
 * Legacy ``&`` or ``§`` formatting - :javadoc:`LegacyComponentSerializer`
 * Configurate nodes - :javadoc:`ConfigurateComponentSerializer`
 * Minecraft JSON - :javadoc:`GsonComponentSerializer`


### PR DESCRIPTION
Fixed a issue where TextSerializer page would have 404 links